### PR TITLE
feat: strengthen shutdown behavior around blocking accept

### DIFF
--- a/.github/workflows/shared-ci.yml
+++ b/.github/workflows/shared-ci.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install --no-install-recommends -y \
-            build-essential clang git libyaml-dev pkg-config
+            build-essential git libyaml-dev pkg-config
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -80,7 +80,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install --no-install-recommends -y \
-            build-essential cmake git libyaml-dev pkg-config
+            build-essential clang git libyaml-dev pkg-config
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -123,7 +123,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install --no-install-recommends -y \
-            build-essential git libyaml-dev pkg-config
+            build-essential cmake git libyaml-dev pkg-config
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/shared-ci.yml
+++ b/.github/workflows/shared-ci.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install --no-install-recommends -y \
-            build-essential git libyaml-dev pkg-config
+            build-essential cmake git libyaml-dev pkg-config
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -201,7 +201,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install --no-install-recommends -y \
-            build-essential git libyaml-dev pkg-config
+            build-essential cmake git libyaml-dev pkg-config
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/shared-ci.yml
+++ b/.github/workflows/shared-ci.yml
@@ -99,6 +99,8 @@ jobs:
           CI_RUBY_VERSION: ${{ matrix.ruby_version }}
       - name: Run Reek
         run: scripts/run-reek-all
+      - name: Run C++ lint
+        run: scripts/run-clint-all
       - name: Validate RBS
         run: scripts/run-rbs-all
 
@@ -218,6 +220,8 @@ jobs:
           CI_RUBY_VERSION: ${{ env.RUBY_VERSION }}
       - name: Build package
         run: scripts/run-package-build-all
+      - name: Run native C++ tests
+        run: scripts/run-ctest-all
 
   build_docs:
     name: Build Docs

--- a/.github/workflows/shared-ci.yml
+++ b/.github/workflows/shared-ci.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install --no-install-recommends -y \
-            build-essential git libyaml-dev pkg-config
+            build-essential clang git libyaml-dev pkg-config
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -80,7 +80,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install --no-install-recommends -y \
-            build-essential git libyaml-dev pkg-config
+            build-essential cmake git libyaml-dev pkg-config
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/gems/vajra/README.md
+++ b/gems/vajra/README.md
@@ -48,6 +48,14 @@ Ruby/package behavior checks. `bin/rspec-e2e` runs the integration-style boot
 check without coverage. `bin/clint` runs the native C++ lint lane, and
 `bin/ctest` builds and runs the native C++ lifecycle tests.
 
+## Runtime Configuration
+
+Vajra reads `VAJRA_PORT` at boot to choose the listener port.
+
+- unset defaults to `3000`
+- any integer in the `0..65535` range is accepted
+- `0` asks the OS for an ephemeral port, which Vajra prints in the startup banner
+
 ## Native Extension
 
 The canonical native source tree lives under `ext/vajra/`.

--- a/gems/vajra/README.md
+++ b/gems/vajra/README.md
@@ -37,13 +37,16 @@ bin/rspec-unit
 bin/rspec-e2e
 bin/rubocop
 bin/reek
+bin/clint
+bin/ctest
 rbs -I sig validate
 bundle exec exe/vajra
 ```
 
 `bin/rspec-unit` runs the committed package spec suite, including the clean
 Ruby/package behavior checks. `bin/rspec-e2e` runs the integration-style boot
-check without coverage.
+check without coverage. `bin/clint` runs the native C++ lint lane, and
+`bin/ctest` builds and runs the native C++ lifecycle tests.
 
 ## Native Extension
 

--- a/gems/vajra/Rakefile
+++ b/gems/vajra/Rakefile
@@ -22,6 +22,16 @@ task :reek do
   sh 'bundle exec reek'
 end
 
+desc 'Lint native C++ sources'
+task :clint do
+  sh 'bin/clint'
+end
+
+desc 'Run native C++ tests'
+task :ctest do
+  sh 'bin/ctest'
+end
+
 desc 'Validate RBS signatures'
 task :rbs do
   sh 'bundle exec rbs -I sig validate'
@@ -34,4 +44,4 @@ Rake::ExtensionTask.new('vajra', GEMSPEC) do |ext|
   ext.lib_dir = 'lib/vajra'
 end
 
-task default: %i[clobber compile spec spec_e2e rubocop reek rbs]
+task default: %i[clobber compile spec spec_e2e rubocop reek clint ctest rbs]

--- a/gems/vajra/bin/clint
+++ b/gems/vajra/bin/clint
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Copyright Codevedas Inc. 2025-present
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+set -euo pipefail
+IFS=$'\n\t'
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+RUBY_CPPFLAGS_ARRAY=()
+while IFS= read -r line; do
+  RUBY_CPPFLAGS_ARRAY+=("$line")
+done < <(
+  ruby -rrbconfig -e '
+    require "shellwords"
+    flags = RbConfig::CONFIG.values_at("CPPFLAGS", "CXXFLAGS").compact.flat_map { |value| Shellwords.split(value) }
+    flags.each { |flag| puts flag }
+  '
+)
+RUBY_INCLUDE_FLAGS_ARRAY=()
+while IFS= read -r line; do
+  RUBY_INCLUDE_FLAGS_ARRAY+=("$line")
+done < <(
+  ruby -rrbconfig -e '
+    [RbConfig::CONFIG["rubyhdrdir"], RbConfig::CONFIG["rubyarchhdrdir"]].compact.uniq.each do |dir|
+      puts "-isystem"
+      puts dir
+    end
+  '
+)
+
+COMMON_FLAGS=(
+  -std=c++17
+  -Wall
+  -Wextra
+  -Wpedantic
+  -Werror
+  -fsyntax-only
+)
+
+clang++ \
+  "${COMMON_FLAGS[@]}" \
+  "${RUBY_CPPFLAGS_ARRAY[@]}" \
+  "${RUBY_INCLUDE_FLAGS_ARRAY[@]}" \
+  -I"$ROOT_DIR/ext/vajra" \
+  "$ROOT_DIR/ext/vajra/server.cpp" \
+  "$ROOT_DIR/ext/vajra/vajra.cpp" \
+  "$@"

--- a/gems/vajra/bin/ctest
+++ b/gems/vajra/bin/ctest
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Copyright Codevedas Inc. 2025-present
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+set -euo pipefail
+IFS=$'\n\t'
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="$ROOT_DIR/tmp/cpp-tests"
+
+rm -rf "$BUILD_DIR"
+cmake -S "$ROOT_DIR/spec/cpp" -B "$BUILD_DIR"
+cmake --build "$BUILD_DIR"
+ctest --test-dir "$BUILD_DIR" --output-on-failure "$@"

--- a/gems/vajra/exe/vajra
+++ b/gems/vajra/exe/vajra
@@ -7,4 +7,5 @@
 # LICENSE file in the root directory of this source tree.
 
 require 'vajra'
+puts Vajra.header
 Vajra.start

--- a/gems/vajra/ext/vajra/server.cpp
+++ b/gems/vajra/ext/vajra/server.cpp
@@ -110,6 +110,12 @@ void Server::start()
 
   running_ = true;
 
+  if (stop_requested_.load() || server_fd_.load() < 0)
+  {
+    close_listener_fd(false);
+    return;
+  }
+
   std::cout << "Vajra listening on port " << port_ << std::endl;
 
   while (running_)

--- a/gems/vajra/ext/vajra/server.cpp
+++ b/gems/vajra/ext/vajra/server.cpp
@@ -11,6 +11,7 @@
 #include <cstring>
 #include <iostream>
 #include <stdexcept>
+#include <string>
 #include <sys/socket.h>
 #include <unistd.h>
 

--- a/gems/vajra/ext/vajra/server.cpp
+++ b/gems/vajra/ext/vajra/server.cpp
@@ -100,6 +100,11 @@ void Server::close_listener_fd(bool interrupt_accept)
 
 void Server::start()
 {
+  if (stop_requested_.load())
+  {
+    return;
+  }
+
   setup_socket();
 
   if (stop_requested_.load())

--- a/gems/vajra/ext/vajra/server.cpp
+++ b/gems/vajra/ext/vajra/server.cpp
@@ -89,7 +89,6 @@ void Server::close_listener_fd(bool interrupt_accept)
 
 void Server::start()
 {
-  stop_requested_ = false;
   setup_socket();
 
   if (stop_requested_.load())

--- a/gems/vajra/ext/vajra/server.cpp
+++ b/gems/vajra/ext/vajra/server.cpp
@@ -24,7 +24,7 @@ namespace
   }
 }
 
-Server::Server(int port) : port_(port), server_fd_(-1), running_(false) {}
+Server::Server(int port) : port_(port), server_fd_(-1), running_(false), stop_requested_(false) {}
 
 Server::~Server()
 {
@@ -89,7 +89,15 @@ void Server::close_listener_fd(bool interrupt_accept)
 
 void Server::start()
 {
+  stop_requested_ = false;
   setup_socket();
+
+  if (stop_requested_.load())
+  {
+    close_listener_fd(false);
+    return;
+  }
+
   running_ = true;
 
   std::cout << "Vajra listening on port " << port_ << std::endl;
@@ -108,7 +116,7 @@ void Server::start()
     int client_fd = accept(listener_fd, reinterpret_cast<sockaddr *>(&client_addr), &client_len);
     if (client_fd < 0)
     {
-      if (!running_ || VajraNative::shutdown_requested())
+      if (!running_ || stop_requested_.load() || VajraNative::shutdown_requested())
       {
         break;
       }
@@ -155,5 +163,6 @@ void Server::start()
 
 void Server::stop()
 {
+  stop_requested_ = true;
   close_listener_fd(true);
 }

--- a/gems/vajra/ext/vajra/server.cpp
+++ b/gems/vajra/ext/vajra/server.cpp
@@ -28,10 +28,7 @@ Server::Server(int port) : port_(port), server_fd_(-1), running_(false) {}
 
 Server::~Server()
 {
-  if (server_fd_ >= 0)
-  {
-    close(server_fd_);
-  }
+  close_listener_fd(false);
 }
 
 void Server::setup_socket()
@@ -69,7 +66,25 @@ void Server::setup_socket()
     throw startup_error("listen", port_, error_number);
   }
 
-  server_fd_ = socket_fd;
+  server_fd_.store(socket_fd);
+}
+
+void Server::close_listener_fd(bool interrupt_accept)
+{
+  running_ = false;
+
+  const int listener_fd = server_fd_.exchange(-1);
+  if (listener_fd < 0)
+  {
+    return;
+  }
+
+  if (interrupt_accept)
+  {
+    shutdown(listener_fd, SHUT_RDWR);
+  }
+
+  close(listener_fd);
 }
 
 void Server::start()
@@ -81,19 +96,20 @@ void Server::start()
 
   while (running_)
   {
+    const int listener_fd = server_fd_.load();
+    if (listener_fd < 0)
+    {
+      break;
+    }
+
     sockaddr_in client_addr{};
     socklen_t client_len = sizeof(client_addr);
 
-    int client_fd = accept(server_fd_, reinterpret_cast<sockaddr *>(&client_addr), &client_len);
+    int client_fd = accept(listener_fd, reinterpret_cast<sockaddr *>(&client_addr), &client_len);
     if (client_fd < 0)
     {
-      if (!running_)
+      if (!running_ || VajraNative::shutdown_requested())
       {
-        break;
-      }
-      if (errno == EINTR && VajraNative::shutdown_requested())
-      {
-        running_ = false;
         break;
       }
       std::cerr << "accept failed: " << std::strerror(errno) << std::endl;
@@ -133,15 +149,11 @@ void Server::start()
     send(client_fd, response, std::strlen(response), 0);
     close(client_fd);
   }
+
+  close_listener_fd(false);
 }
 
 void Server::stop()
 {
-  running_ = false;
-
-  if (server_fd_ >= 0)
-  {
-    close(server_fd_);
-    server_fd_ = -1;
-  }
+  close_listener_fd(true);
 }

--- a/gems/vajra/ext/vajra/server.cpp
+++ b/gems/vajra/ext/vajra/server.cpp
@@ -59,6 +59,17 @@ void Server::setup_socket()
     throw startup_error("bind", port_, error_number);
   }
 
+  sockaddr_in bound_addr{};
+  socklen_t bound_addr_len = sizeof(bound_addr);
+  if (getsockname(socket_fd, reinterpret_cast<sockaddr *>(&bound_addr), &bound_addr_len) < 0)
+  {
+    const int error_number = errno;
+    close(socket_fd);
+    throw startup_error("bound port discovery", port_, error_number);
+  }
+
+  port_ = ntohs(bound_addr.sin_port);
+
   if (listen(socket_fd, 128) < 0)
   {
     const int error_number = errno;

--- a/gems/vajra/ext/vajra/server.hpp
+++ b/gems/vajra/ext/vajra/server.hpp
@@ -21,6 +21,7 @@ private:
   int port_;
   std::atomic<int> server_fd_;
   std::atomic<bool> running_;
+  std::atomic<bool> stop_requested_;
 
   void setup_socket();
   void close_listener_fd(bool interrupt_accept);

--- a/gems/vajra/ext/vajra/server.hpp
+++ b/gems/vajra/ext/vajra/server.hpp
@@ -19,10 +19,11 @@ public:
 
 private:
   int port_;
-  int server_fd_;
+  std::atomic<int> server_fd_;
   std::atomic<bool> running_;
 
   void setup_socket();
+  void close_listener_fd(bool interrupt_accept);
 };
 
 #endif

--- a/gems/vajra/ext/vajra/vajra.cpp
+++ b/gems/vajra/ext/vajra/vajra.cpp
@@ -7,6 +7,8 @@
 #include "ruby.h"
 
 #include <csignal>
+#include <cstdlib>
+#include <cerrno>
 #include <iostream>
 #include <memory>
 #include <mutex>
@@ -76,6 +78,25 @@ namespace
     rb_raise(rb_eRuntimeError, "%s: %s", prefix, error.what());
   }
 
+  int configured_listener_port()
+  {
+    const char *port_value = std::getenv("VAJRA_PORT");
+    if (port_value == nullptr || port_value[0] == '\0')
+    {
+      return 3000;
+    }
+
+    errno = 0;
+    char *end = nullptr;
+    const long port = std::strtol(port_value, &end, 10);
+    if (errno != 0 || end == port_value || *end != '\0' || port <= 0 || port > 65'535)
+    {
+      throw std::runtime_error(std::string("invalid VAJRA_PORT: ") + port_value);
+    }
+
+    return static_cast<int>(port);
+  }
+
   VALUE rb_vajra_start(VALUE self)
   {
     (void)self;
@@ -129,7 +150,7 @@ namespace VajraNative
         }
 
         shutting_down = 0;
-        server_instance = std::make_unique<Server>(3000);
+        server_instance = std::make_unique<Server>(configured_listener_port());
         server = server_instance.get();
       }
 

--- a/gems/vajra/ext/vajra/vajra.cpp
+++ b/gems/vajra/ext/vajra/vajra.cpp
@@ -16,6 +16,7 @@
 #include <mutex>
 #include <stdexcept>
 #include <cstring>
+#include <string>
 
 namespace
 {
@@ -113,10 +114,11 @@ namespace
     errno = 0;
     char *end = nullptr;
     const long port = std::strtol(port_value, &end, 10);
-    if (errno != 0 || end == port_value || *end != '\0' || port <= 0 || port > 65'535)
+    if (errno != 0 || end == port_value || *end != '\0' || port < 0 || port > 65'535)
     {
       throw std::runtime_error(
-          std::string("invalid VAJRA_PORT: ") + port_value + ". Expected an integer between 1 and 65535.");
+          std::string("invalid VAJRA_PORT: ") + port_value +
+          ". Expected an integer between 0 and 65535. Use 0 to request an ephemeral port.");
     }
 
     return static_cast<int>(port);

--- a/gems/vajra/ext/vajra/vajra.cpp
+++ b/gems/vajra/ext/vajra/vajra.cpp
@@ -115,7 +115,8 @@ namespace
     const long port = std::strtol(port_value, &end, 10);
     if (errno != 0 || end == port_value || *end != '\0' || port <= 0 || port > 65'535)
     {
-      throw std::runtime_error(std::string("invalid VAJRA_PORT: ") + port_value);
+      throw std::runtime_error(
+          std::string("invalid VAJRA_PORT: ") + port_value + ". Expected an integer between 1 and 65535.");
     }
 
     return static_cast<int>(port);

--- a/gems/vajra/ext/vajra/vajra.cpp
+++ b/gems/vajra/ext/vajra/vajra.cpp
@@ -5,10 +5,12 @@
 
 #include "vajra.hpp"
 #include "ruby.h"
+#include "ruby/thread.h"
 
 #include <csignal>
 #include <cstdlib>
 #include <cerrno>
+#include <exception>
 #include <iostream>
 #include <memory>
 #include <mutex>
@@ -72,6 +74,28 @@ namespace
     struct sigaction previous_term_action_;
     bool installed_ = false;
   };
+
+  struct ServerStartContext
+  {
+    Server *server;
+    std::exception_ptr error;
+  };
+
+  void *run_server_without_gvl(void *data)
+  {
+    auto *context = static_cast<ServerStartContext *>(data);
+
+    try
+    {
+      context->server->start();
+    }
+    catch (...)
+    {
+      context->error = std::current_exception();
+    }
+
+    return nullptr;
+  }
 
   [[noreturn]] void raise_ruby_runtime_error(const char *prefix, const std::exception &error)
   {
@@ -154,7 +178,12 @@ namespace VajraNative
         server = server_instance.get();
       }
 
-      server->start();
+      ServerStartContext context{server, nullptr};
+      rb_thread_call_without_gvl(run_server_without_gvl, &context, RUBY_UBF_IO, nullptr);
+      if (context.error)
+      {
+        std::rethrow_exception(context.error);
+      }
     }
     catch (...)
     {

--- a/gems/vajra/lib/vajra.rb
+++ b/gems/vajra/lib/vajra.rb
@@ -30,13 +30,6 @@ module Vajra
   NativeExtension.load!
 
   class << self
-    alias native_start start
-
-    def start
-      puts header
-      native_start
-    end
-
     def header
       art = <<~'TEXT'
         __      __  _         _   ____       _

--- a/gems/vajra/lib/vajra.rb
+++ b/gems/vajra/lib/vajra.rb
@@ -7,6 +7,7 @@
 
 require_relative 'vajra/version'
 
+# Ruby entrypoint for booting the native Vajra HTTP listener.
 module Vajra
   # Base error type for Ruby-side Vajra failures.
   class Error < StandardError; end
@@ -25,6 +26,27 @@ module Vajra
       MESSAGE
     end
   end
-end
 
-Vajra::NativeExtension.load!
+  NativeExtension.load!
+
+  class << self
+    alias native_start start
+
+    def start
+      puts header
+      native_start
+    end
+
+    def header
+      art = <<~'TEXT'
+        __      __  _         _   ____       _
+        \ \    / / / \       | | |  _ \     / \
+         \ \  / / / _ \   _  | | | |_) |   / _ \
+          \ \/ / / ___ \ | |_| | |  _ <   / ___ \
+           \__/ /_/   \_\ \___/  |_| \_\ /_/   \_\
+      TEXT
+
+      "#{art}\nv#{Vajra::VERSION}\n"
+    end
+  end
+end

--- a/gems/vajra/sig/vajra.rbs
+++ b/gems/vajra/sig/vajra.rbs
@@ -5,5 +5,8 @@
 
 module Vajra
   VERSION: String
-  # See the writing guide of rbs: https://github.com/ruby/rbs#guides
+
+  def self.header: () -> String
+  def self.start: () -> untyped
+  def self.stop: () -> untyped
 end

--- a/gems/vajra/sig/vajra.rbs
+++ b/gems/vajra/sig/vajra.rbs
@@ -7,6 +7,6 @@ module Vajra
   VERSION: String
 
   def self.header: () -> String
-  def self.start: () -> untyped
-  def self.stop: () -> untyped
+  def self.start: () -> nil
+  def self.stop: () -> nil
 end

--- a/gems/vajra/spec/cpp/CMakeLists.txt
+++ b/gems/vajra/spec/cpp/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.20)
+project(vajra_cpp_tests LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+find_package(Threads REQUIRED)
+
+add_executable(vajra_server_test
+  server_test.cpp
+  ../../ext/vajra/server.cpp
+)
+
+target_include_directories(vajra_server_test PRIVATE ../../ext/vajra)
+target_link_libraries(vajra_server_test PRIVATE Threads::Threads)
+target_compile_options(vajra_server_test PRIVATE -Wall -Wextra -Wpedantic -Werror)
+
+enable_testing()
+add_test(NAME vajra_server_test COMMAND vajra_server_test)

--- a/gems/vajra/spec/cpp/server_test.cpp
+++ b/gems/vajra/spec/cpp/server_test.cpp
@@ -35,6 +35,27 @@ namespace
     throw std::runtime_error(message);
   }
 
+  bool bind_conflict(const std::exception_ptr &error)
+  {
+    if (!error)
+    {
+      return false;
+    }
+
+    try
+    {
+      std::rethrow_exception(error);
+    }
+    catch (const std::runtime_error &runtime_error)
+    {
+      return std::string(runtime_error.what()).find("Address already in use") != std::string::npos;
+    }
+    catch (...)
+    {
+      return false;
+    }
+  }
+
   int available_port()
   {
     const int fd = socket(AF_INET, SOCK_STREAM, 0);
@@ -159,32 +180,55 @@ namespace
 
   void test_start_and_stop_release_listener()
   {
-    const int port = available_port();
-    Server server(port);
-    std::exception_ptr server_error;
+    for (int attempt = 0; attempt < 10; ++attempt)
+    {
+      const int port = available_port();
+      Server server(port);
+      std::exception_ptr server_error;
 
-    std::thread server_thread([&]() {
+      std::thread server_thread([&]() {
+        try
+        {
+          server.start();
+        }
+        catch (...)
+        {
+          server_error = std::current_exception();
+        }
+      });
+
       try
       {
-        server.start();
+        wait_until_listening(port);
+        server.stop();
+        server_thread.join();
+
+        if (server_error)
+        {
+          std::rethrow_exception(server_error);
+        }
+
+        assert_can_rebind(port);
+        return;
       }
       catch (...)
       {
-        server_error = std::current_exception();
+        if (server_thread.joinable())
+        {
+          server.stop();
+          server_thread.join();
+        }
+
+        if (bind_conflict(server_error) && attempt < 9)
+        {
+          continue;
+        }
+
+        throw;
       }
-    });
-
-    wait_until_listening(port);
-    server.stop();
-
-    server_thread.join();
-
-    if (server_error)
-    {
-      std::rethrow_exception(server_error);
     }
 
-    assert_can_rebind(port);
+    fail("server could not obtain a reusable listener port after retries");
   }
 
   void test_stop_before_start_exits_cleanly()

--- a/gems/vajra/spec/cpp/server_test.cpp
+++ b/gems/vajra/spec/cpp/server_test.cpp
@@ -1,0 +1,191 @@
+// Copyright Codevedas Inc. 2025-present
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "server.hpp"
+
+#include <arpa/inet.h>
+#include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <exception>
+#include <iostream>
+#include <netinet/in.h>
+#include <stdexcept>
+#include <string>
+#include <sys/socket.h>
+#include <thread>
+#include <unistd.h>
+
+namespace VajraNative
+{
+  bool shutdown_requested()
+  {
+    return false;
+  }
+}
+
+namespace
+{
+  using namespace std::chrono_literals;
+
+  [[noreturn]] void fail(const std::string &message)
+  {
+    throw std::runtime_error(message);
+  }
+
+  int available_port()
+  {
+    const int fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0)
+    {
+      fail("socket failed while allocating test port");
+    }
+
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = htons(0);
+
+    if (bind(fd, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) < 0)
+    {
+      close(fd);
+      fail("bind failed while allocating test port");
+    }
+
+    socklen_t len = sizeof(addr);
+    if (getsockname(fd, reinterpret_cast<sockaddr *>(&addr), &len) < 0)
+    {
+      close(fd);
+      fail("getsockname failed while allocating test port");
+    }
+
+    const int port = ntohs(addr.sin_port);
+    close(fd);
+    return port;
+  }
+
+  int connect_to_listener(int port)
+  {
+    const int fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0)
+    {
+      fail("socket failed while connecting to test listener");
+    }
+
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port);
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+
+    if (connect(fd, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) < 0)
+    {
+      close(fd);
+      return -1;
+    }
+
+    return fd;
+  }
+
+  void wait_until_listening(int port)
+  {
+    for (int attempt = 0; attempt < 200; ++attempt)
+    {
+      const int fd = connect_to_listener(port);
+      if (fd >= 0)
+      {
+        close(fd);
+        return;
+      }
+
+      std::this_thread::sleep_for(10ms);
+    }
+
+    fail("server did not begin listening in time");
+  }
+
+  void assert_can_rebind(int port)
+  {
+    const int fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0)
+    {
+      fail("socket failed while checking port rebind");
+    }
+
+    int opt = 1;
+    if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) < 0)
+    {
+      close(fd);
+      fail("setsockopt failed while checking port rebind");
+    }
+
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    addr.sin_port = htons(port);
+
+    if (bind(fd, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) < 0)
+    {
+      close(fd);
+      fail("listener port was not released after stop");
+    }
+
+    close(fd);
+  }
+
+  void test_start_and_stop_release_listener()
+  {
+    const int port = available_port();
+    Server server(port);
+    std::exception_ptr server_error;
+
+    std::thread server_thread([&]() {
+      try
+      {
+        server.start();
+      }
+      catch (...)
+      {
+        server_error = std::current_exception();
+      }
+    });
+
+    wait_until_listening(port);
+    server.stop();
+
+    server_thread.join();
+
+    if (server_error)
+    {
+      std::rethrow_exception(server_error);
+    }
+
+    assert_can_rebind(port);
+  }
+
+  void test_stop_before_start_exits_cleanly()
+  {
+    const int port = available_port();
+    Server server(port);
+    server.stop();
+    server.start();
+    assert_can_rebind(port);
+  }
+}
+
+int main()
+{
+  try
+  {
+    test_start_and_stop_release_listener();
+    test_stop_before_start_exits_cleanly();
+  }
+  catch (const std::exception &error)
+  {
+    std::cerr << error.what() << '\n';
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/gems/vajra/spec/cpp/server_test.cpp
+++ b/gems/vajra/spec/cpp/server_test.cpp
@@ -4,6 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 
 #include "server.hpp"
+#include "vajra.hpp"
 
 #include <arpa/inet.h>
 #include <chrono>

--- a/gems/vajra/spec/cpp/server_test.cpp
+++ b/gems/vajra/spec/cpp/server_test.cpp
@@ -88,6 +88,25 @@ namespace
     return fd;
   }
 
+  bool complete_probe_request(int fd)
+  {
+    const char *request =
+        "GET / HTTP/1.1\r\n"
+        "Host: localhost\r\n"
+        "Connection: close\r\n"
+        "\r\n";
+
+    const ssize_t bytes_sent = send(fd, request, std::strlen(request), 0);
+    if (bytes_sent < 0)
+    {
+      return false;
+    }
+
+    char buffer[4096];
+    const ssize_t bytes_read = recv(fd, buffer, sizeof(buffer), 0);
+    return bytes_read > 0;
+  }
+
   void wait_until_listening(int port)
   {
     for (int attempt = 0; attempt < 200; ++attempt)
@@ -95,8 +114,12 @@ namespace
       const int fd = connect_to_listener(port);
       if (fd >= 0)
       {
+        const bool completed_request = complete_probe_request(fd);
         close(fd);
-        return;
+        if (completed_request)
+        {
+          return;
+        }
       }
 
       std::this_thread::sleep_for(10ms);

--- a/gems/vajra/spec/e2e/spec_helper.rb
+++ b/gems/vajra/spec/e2e/spec_helper.rb
@@ -13,18 +13,39 @@ require 'timeout'
 
 module VajraE2EHelpers
   PACKAGE_ROOT = File.expand_path('../..', __dir__)
+  LISTENER_HOST = '127.0.0.1'
+  LISTENER_BIND_HOST = '0.0.0.0'
 
   def vajra_command(*args)
     ['bundle', 'exec', RbConfig.ruby, '-Ilib', 'exe/vajra', *args]
   end
 
-  def wait_for_banner(output)
+  def inline_ruby_command(script)
+    ['bundle', 'exec', RbConfig.ruby, '-Ilib', '-e', script]
+  end
+
+  def available_listener_port
+    server = TCPServer.new(LISTENER_HOST, 0)
+    server.addr[1]
+  ensure
+    server&.close
+  end
+
+  def vajra_env(port)
+    { 'VAJRA_PORT' => port.to_s }
+  end
+
+  def listener_banner(port)
+    "Vajra listening on port #{port}"
+  end
+
+  def wait_for_banner(output, port:)
     Timeout.timeout(15) do
       loop do
         line = output.gets
         raise 'vajra exited before startup banner' if line.nil?
 
-        return if line.include?('Vajra listening on port 3000')
+        return if line.include?(listener_banner(port))
       end
     end
   end

--- a/gems/vajra/spec/e2e/spec_helper.rb
+++ b/gems/vajra/spec/e2e/spec_helper.rb
@@ -24,13 +24,6 @@ module VajraE2EHelpers
     ['bundle', 'exec', RbConfig.ruby, '-Ilib', '-e', script]
   end
 
-  def available_listener_port
-    server = TCPServer.new(LISTENER_BIND_HOST, 0)
-    server.addr[1]
-  ensure
-    server&.close
-  end
-
   def vajra_env(port)
     { 'VAJRA_PORT' => port.to_s }
   end
@@ -39,13 +32,14 @@ module VajraE2EHelpers
     "Vajra listening on port #{port}"
   end
 
-  def wait_for_banner(output, port:)
+  def wait_for_banner(output)
     Timeout.timeout(15) do
       loop do
         line = output.gets
         raise 'vajra exited before startup banner' if line.nil?
 
-        return if line.include?(listener_banner(port))
+        match = line.match(/Vajra listening on port (\d+)/)
+        return Integer(match[1]) if match
       end
     end
   end

--- a/gems/vajra/spec/e2e/spec_helper.rb
+++ b/gems/vajra/spec/e2e/spec_helper.rb
@@ -25,7 +25,7 @@ module VajraE2EHelpers
   end
 
   def available_listener_port
-    server = TCPServer.new(LISTENER_HOST, 0)
+    server = TCPServer.new(LISTENER_BIND_HOST, 0)
     server.addr[1]
   ensure
     server&.close

--- a/gems/vajra/spec/e2e/vajra/vajra_spec.rb
+++ b/gems/vajra/spec/e2e/vajra/vajra_spec.rb
@@ -8,6 +8,8 @@
 require_relative '../spec_helper'
 
 RSpec.describe Vajra, :e2e, :integration do
+  let(:listener_port) { available_listener_port }
+
   def wait_for_exit(wait_thread, timeout: 5)
     Timeout.timeout(timeout) { wait_thread.value }
   end
@@ -35,11 +37,11 @@ RSpec.describe Vajra, :e2e, :integration do
     output.close unless output.closed?
   end
 
-  def request_response
-    Open3.popen2e(*vajra_command, chdir: VajraE2EHelpers::PACKAGE_ROOT) do |_stdin, output, wait_thread|
-      wait_for_banner(output)
+  def request_response(port: listener_port)
+    Open3.popen2e(vajra_env(port), *vajra_command, chdir: VajraE2EHelpers::PACKAGE_ROOT) do |_stdin, output, wait_thread|
+      wait_for_banner(output, port: port)
 
-      socket = TCPSocket.new('127.0.0.1', 3000)
+      socket = TCPSocket.new(VajraE2EHelpers::LISTENER_HOST, port)
       socket.write("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
       response = socket.read
       socket.close
@@ -52,9 +54,9 @@ RSpec.describe Vajra, :e2e, :integration do
     end
   end
 
-  def idle_shutdown
-    Open3.popen2e(*vajra_command, chdir: VajraE2EHelpers::PACKAGE_ROOT) do |_stdin, output, wait_thread|
-      wait_for_banner(output)
+  def idle_shutdown(port: listener_port)
+    Open3.popen2e(vajra_env(port), *vajra_command, chdir: VajraE2EHelpers::PACKAGE_ROOT) do |_stdin, output, wait_thread|
+      wait_for_banner(output, port: port)
 
       status = stop_process(wait_thread)
 
@@ -64,8 +66,8 @@ RSpec.describe Vajra, :e2e, :integration do
     end
   end
 
-  def startup_failure
-    Open3.popen2e(*vajra_command, chdir: VajraE2EHelpers::PACKAGE_ROOT) do |_stdin, output, wait_thread|
+  def startup_failure(port: listener_port)
+    Open3.popen2e(vajra_env(port), *vajra_command, chdir: VajraE2EHelpers::PACKAGE_ROOT) do |_stdin, output, wait_thread|
       status = Timeout.timeout(15) { wait_thread.value }
       { exitstatus: status.exitstatus, output: output.read }
     ensure
@@ -73,8 +75,12 @@ RSpec.describe Vajra, :e2e, :integration do
     end
   end
 
-  def bind_port
-    TCPServer.new('0.0.0.0', 3000)
+  def bind_port(port: listener_port)
+    TCPServer.new(VajraE2EHelpers::LISTENER_BIND_HOST, port)
+  end
+
+  def thrash_cycles
+    5
   end
 
   it 'boots and serves a basic HTTP response' do
@@ -101,20 +107,39 @@ RSpec.describe Vajra, :e2e, :integration do
 
   it 'fails startup with actionable bind diagnostics and releases startup resources' do
     blocking_server = bind_port
+    blocked_port = blocking_server.addr[1]
 
     begin
-      failure = startup_failure
+      failure = startup_failure(port: blocked_port)
 
       expect(failure).to match(
         exitstatus: a_value > 0,
-        output: a_string_including('Unable to start Vajra: listener bind failed for port 3000')
+        output: a_string_including(
+          "Unable to start Vajra: listener bind failed for port #{blocked_port}"
+        )
       )
-      expect(failure[:output]).not_to include('Vajra listening on port 3000')
+      expect(failure[:output]).not_to include(listener_banner(blocked_port))
     ensure
       blocking_server.close
     end
 
-    rebound_server = bind_port
+    rebound_server = bind_port(port: blocked_port)
     rebound_server.close
+  end
+
+  it 'survives repeated process start stop thrashing and releases the listener every time' do
+    thrash_cycles.times do
+      expect(request_response).to match(
+        exitstatus: 0,
+        response: a_string_including('HTTP/1.1 200 OK')
+      )
+
+      shutdown = idle_shutdown
+      expect(shutdown[:exitstatus]).to eq(0)
+      expect(shutdown[:output]).not_to include('accept failed')
+
+      rebound_server = bind_port
+      rebound_server.close
+    end
   end
 end

--- a/gems/vajra/spec/e2e/vajra/vajra_spec.rb
+++ b/gems/vajra/spec/e2e/vajra/vajra_spec.rb
@@ -75,6 +75,49 @@ RSpec.describe Vajra, :e2e, :integration do
     end
   end
 
+  def programmatic_shutdown(port: listener_port)
+    script = <<~RUBY
+      require "socket"
+      require "timeout"
+      require "vajra"
+
+      port = Integer(ENV.fetch("VAJRA_PORT"))
+      host = "#{VajraE2EHelpers::LISTENER_HOST}"
+      bind_host = "#{VajraE2EHelpers::LISTENER_BIND_HOST}"
+      Thread.report_on_exception = false
+
+      def listener_ready?(host, port)
+        socket = TCPSocket.new(host, port)
+        socket.close
+        true
+      rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+        false
+      end
+
+      server_thread = Thread.new { Vajra.start }
+
+      Timeout.timeout(5) do
+        loop do
+          break if listener_ready?(host, port)
+          sleep 0.01
+        end
+      end
+
+      Vajra.stop
+      Timeout.timeout(5) { server_thread.join }
+
+      rebound_server = TCPServer.new(bind_host, port)
+      rebound_server.close
+    RUBY
+
+    Open3.popen2e(vajra_env(port), *inline_ruby_command(script), chdir: VajraE2EHelpers::PACKAGE_ROOT) do |_stdin, output, wait_thread|
+      status = Timeout.timeout(15) { wait_thread.value }
+      { exitstatus: status.exitstatus, output: output.read }
+    ensure
+      cleanup_process(wait_thread, output)
+    end
+  end
+
   def bind_port(port: listener_port)
     TCPServer.new(VajraE2EHelpers::LISTENER_BIND_HOST, port)
   end
@@ -103,6 +146,13 @@ RSpec.describe Vajra, :e2e, :integration do
       exitstatus: 0,
       response: a_string_including('HTTP/1.1 200 OK')
     )
+  end
+
+  it 'supports programmatic Vajra.stop and releases the listener' do
+    shutdown = programmatic_shutdown
+
+    expect(shutdown[:exitstatus]).to eq(0), shutdown[:output]
+    expect(shutdown[:output]).not_to include('accept failed')
   end
 
   it 'fails startup with actionable bind diagnostics and releases startup resources' do

--- a/gems/vajra/spec/e2e/vajra/vajra_spec.rb
+++ b/gems/vajra/spec/e2e/vajra/vajra_spec.rb
@@ -162,10 +162,10 @@ RSpec.describe Vajra, :e2e, :integration do
     expect(shutdown[:exitstatus]).to eq(0)
     expect(shutdown[:output]).not_to include('accept failed')
 
-    rebound_server = bind_port
+    rebound_server = bind_port(port: shutdown[:port])
     rebound_server.close
 
-    expect(request_response).to include(
+    expect(request_response(port: shutdown[:port])).to include(
       exitstatus: 0,
       response: a_string_including('HTTP/1.1 200 OK')
     )
@@ -201,17 +201,22 @@ RSpec.describe Vajra, :e2e, :integration do
   end
 
   it 'survives repeated process start stop thrashing and releases the listener every time' do
+    current_port = disposable_listener_port
+
     thrash_cycles.times do
-      expect(request_response).to include(
+      request = request_response(port: current_port)
+
+      expect(request).to include(
         exitstatus: 0,
         response: a_string_including('HTTP/1.1 200 OK')
       )
+      current_port = request[:port]
 
-      shutdown = idle_shutdown
+      shutdown = idle_shutdown(port: current_port)
       expect(shutdown[:exitstatus]).to eq(0)
       expect(shutdown[:output]).not_to include('accept failed')
 
-      rebound_server = bind_port
+      rebound_server = bind_port(port: current_port)
       rebound_server.close
     end
   end

--- a/gems/vajra/spec/e2e/vajra/vajra_spec.rb
+++ b/gems/vajra/spec/e2e/vajra/vajra_spec.rb
@@ -89,6 +89,19 @@ RSpec.describe Vajra, :e2e, :integration do
     end
   end
 
+  def startup_failure_with_env(port_value)
+    Open3.popen2e(
+      { 'VAJRA_PORT' => port_value },
+      *vajra_command,
+      chdir: VajraE2EHelpers::PACKAGE_ROOT
+    ) do |_stdin, output, wait_thread|
+      status = Timeout.timeout(15) { wait_thread.value }
+      { exitstatus: status.exitstatus, output: output.read }
+    ensure
+      cleanup_process(wait_thread, output)
+    end
+  end
+
   def programmatic_shutdown(max_attempts: 3)
     script = <<~RUBY
       require "socket"
@@ -198,6 +211,17 @@ RSpec.describe Vajra, :e2e, :integration do
 
     rebound_server = bind_port(port: blocked_port)
     rebound_server.close
+  end
+
+  it 'fails startup with actionable VAJRA_PORT validation errors' do
+    failure = startup_failure_with_env('not-a-port')
+
+    expect(failure).to match(
+      exitstatus: be_positive,
+      output: a_string_including('Unable to start Vajra: invalid VAJRA_PORT: not-a-port')
+    )
+    expect(failure[:output]).to include('Expected an integer between 0 and 65535')
+    expect(failure[:output]).to include('Use 0 to request an ephemeral port')
   end
 
   it 'survives repeated process start stop thrashing and releases the listener every time' do

--- a/gems/vajra/spec/e2e/vajra/vajra_spec.rb
+++ b/gems/vajra/spec/e2e/vajra/vajra_spec.rb
@@ -8,8 +8,6 @@
 require_relative '../spec_helper'
 
 RSpec.describe Vajra, :e2e, :integration do
-  let(:listener_port) { available_listener_port }
-
   def wait_for_exit(wait_thread, timeout: 5)
     Timeout.timeout(timeout) { wait_thread.value }
   end
@@ -37,36 +35,52 @@ RSpec.describe Vajra, :e2e, :integration do
     output.close unless output.closed?
   end
 
-  def request_response(port: listener_port)
-    Open3.popen2e(vajra_env(port), *vajra_command, chdir: VajraE2EHelpers::PACKAGE_ROOT) do |_stdin, output, wait_thread|
-      wait_for_banner(output, port: port)
+  def bind_conflict_output?(output, port)
+    output.include?("Unable to start Vajra: listener bind failed for port #{port}") &&
+      output.include?('Address already in use')
+  end
 
-      socket = TCPSocket.new(VajraE2EHelpers::LISTENER_HOST, port)
+  def disposable_listener_port
+    0
+  end
+
+  def candidate_listener_port
+    server = TCPServer.new(VajraE2EHelpers::LISTENER_BIND_HOST, 0)
+    server.addr[1]
+  ensure
+    server&.close
+  end
+
+  def request_response(port: disposable_listener_port)
+    Open3.popen2e(vajra_env(port), *vajra_command, chdir: VajraE2EHelpers::PACKAGE_ROOT) do |_stdin, output, wait_thread|
+      selected_port = wait_for_banner(output)
+
+      socket = TCPSocket.new(VajraE2EHelpers::LISTENER_HOST, selected_port)
       socket.write("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
       response = socket.read
       socket.close
 
       status = stop_process(wait_thread)
 
-      { exitstatus: status.exitstatus, response: response }
+      { exitstatus: status.exitstatus, response: response, port: selected_port }
     ensure
       cleanup_process(wait_thread, output)
     end
   end
 
-  def idle_shutdown(port: listener_port)
+  def idle_shutdown(port: disposable_listener_port)
     Open3.popen2e(vajra_env(port), *vajra_command, chdir: VajraE2EHelpers::PACKAGE_ROOT) do |_stdin, output, wait_thread|
-      wait_for_banner(output, port: port)
+      selected_port = wait_for_banner(output)
 
       status = stop_process(wait_thread)
 
-      { exitstatus: status.exitstatus, output: output.read }
+      { exitstatus: status.exitstatus, output: output.read, port: selected_port }
     ensure
       cleanup_process(wait_thread, output)
     end
   end
 
-  def startup_failure(port: listener_port)
+  def startup_failure(port:)
     Open3.popen2e(vajra_env(port), *vajra_command, chdir: VajraE2EHelpers::PACKAGE_ROOT) do |_stdin, output, wait_thread|
       status = Timeout.timeout(15) { wait_thread.value }
       { exitstatus: status.exitstatus, output: output.read }
@@ -75,7 +89,7 @@ RSpec.describe Vajra, :e2e, :integration do
     end
   end
 
-  def programmatic_shutdown(port: listener_port)
+  def programmatic_shutdown(max_attempts: 3)
     script = <<~RUBY
       require "socket"
       require "timeout"
@@ -110,15 +124,24 @@ RSpec.describe Vajra, :e2e, :integration do
       rebound_server.close
     RUBY
 
-    Open3.popen2e(vajra_env(port), *inline_ruby_command(script), chdir: VajraE2EHelpers::PACKAGE_ROOT) do |_stdin, output, wait_thread|
-      status = Timeout.timeout(15) { wait_thread.value }
-      { exitstatus: status.exitstatus, output: output.read }
-    ensure
-      cleanup_process(wait_thread, output)
+    max_attempts.times do |attempt|
+      selected_port = candidate_listener_port
+      result = Open3.popen2e(
+        vajra_env(selected_port), *inline_ruby_command(script), chdir: VajraE2EHelpers::PACKAGE_ROOT
+      ) do |_stdin, output, wait_thread|
+        status = Timeout.timeout(15) { wait_thread.value }
+        { exitstatus: status.exitstatus, output: output.read }
+      ensure
+        cleanup_process(wait_thread, output)
+      end
+
+      next if bind_conflict_output?(result[:output], selected_port) && attempt < max_attempts - 1
+
+      return result
     end
   end
 
-  def bind_port(port: listener_port)
+  def bind_port(port: disposable_listener_port)
     TCPServer.new(VajraE2EHelpers::LISTENER_BIND_HOST, port)
   end
 
@@ -127,7 +150,7 @@ RSpec.describe Vajra, :e2e, :integration do
   end
 
   it 'boots and serves a basic HTTP response' do
-    expect(request_response).to match(
+    expect(request_response).to include(
       exitstatus: 0,
       response: a_string_including('HTTP/1.1 200 OK')
     )
@@ -142,7 +165,7 @@ RSpec.describe Vajra, :e2e, :integration do
     rebound_server = bind_port
     rebound_server.close
 
-    expect(request_response).to match(
+    expect(request_response).to include(
       exitstatus: 0,
       response: a_string_including('HTTP/1.1 200 OK')
     )
@@ -179,7 +202,7 @@ RSpec.describe Vajra, :e2e, :integration do
 
   it 'survives repeated process start stop thrashing and releases the listener every time' do
     thrash_cycles.times do
-      expect(request_response).to match(
+      expect(request_response).to include(
         exitstatus: 0,
         response: a_string_including('HTTP/1.1 200 OK')
       )

--- a/gems/vajra/spec/e2e/vajra/vajra_spec.rb
+++ b/gems/vajra/spec/e2e/vajra/vajra_spec.rb
@@ -52,6 +52,18 @@ RSpec.describe Vajra, :e2e, :integration do
     end
   end
 
+  def idle_shutdown
+    Open3.popen2e(*vajra_command, chdir: VajraE2EHelpers::PACKAGE_ROOT) do |_stdin, output, wait_thread|
+      wait_for_banner(output)
+
+      status = stop_process(wait_thread)
+
+      { exitstatus: status.exitstatus, output: output.read }
+    ensure
+      cleanup_process(wait_thread, output)
+    end
+  end
+
   def startup_failure
     Open3.popen2e(*vajra_command, chdir: VajraE2EHelpers::PACKAGE_ROOT) do |_stdin, output, wait_thread|
       status = Timeout.timeout(15) { wait_thread.value }
@@ -66,6 +78,21 @@ RSpec.describe Vajra, :e2e, :integration do
   end
 
   it 'boots and serves a basic HTTP response' do
+    expect(request_response).to match(
+      exitstatus: 0,
+      response: a_string_including('HTTP/1.1 200 OK')
+    )
+  end
+
+  it 'shuts down cleanly while idle and releases the listener for immediate restart' do
+    shutdown = idle_shutdown
+
+    expect(shutdown[:exitstatus]).to eq(0)
+    expect(shutdown[:output]).not_to include('accept failed')
+
+    rebound_server = bind_port
+    rebound_server.close
+
     expect(request_response).to match(
       exitstatus: 0,
       response: a_string_including('HTTP/1.1 200 OK')

--- a/gems/vajra/spec/e2e/vajra/vajra_spec.rb
+++ b/gems/vajra/spec/e2e/vajra/vajra_spec.rb
@@ -186,7 +186,7 @@ RSpec.describe Vajra, :e2e, :integration do
       failure = startup_failure(port: blocked_port)
 
       expect(failure).to match(
-        exitstatus: a_value > 0,
+        exitstatus: be_positive,
         output: a_string_including(
           "Unable to start Vajra: listener bind failed for port #{blocked_port}"
         )

--- a/gems/vajra/spec/vajra_spec.rb
+++ b/gems/vajra/spec/vajra_spec.rb
@@ -20,6 +20,18 @@ RSpec.describe Vajra do
     ).to eq([true, true])
   end
 
+  it 'builds a versioned ASCII header' do
+    expect(described_class.header).to include('__      __')
+    expect(described_class.header).to include('v0.1.0')
+  end
+
+  it 'prints the header before delegating to the native start entrypoint' do
+    allow(described_class).to receive(:native_start)
+
+    expect { described_class.start }.to output(include('v0.1.0')).to_stdout
+    expect(described_class).to have_received(:native_start)
+  end
+
   it 'raises an actionable error when the native extension cannot be loaded' do
     expect { described_class::NativeExtension.load!(loader: failing_loader) }.to raise_error(
       LoadError,

--- a/gems/vajra/spec/vajra_spec.rb
+++ b/gems/vajra/spec/vajra_spec.rb
@@ -25,11 +25,9 @@ RSpec.describe Vajra do
     expect(described_class.header).to include("v#{described_class::VERSION}")
   end
 
-  it 'prints the header before delegating to the native start entrypoint' do
-    allow(described_class).to receive(:native_start)
-
-    expect { described_class.start }.to output(include("v#{described_class::VERSION}")).to_stdout
-    expect(described_class).to have_received(:native_start)
+  it 'keeps the native start entrypoint public' do
+    expect(described_class).to respond_to(:start)
+    expect(described_class.singleton_methods).not_to include(:native_start)
   end
 
   it 'raises an actionable error when the native extension cannot be loaded' do

--- a/gems/vajra/spec/vajra_spec.rb
+++ b/gems/vajra/spec/vajra_spec.rb
@@ -22,13 +22,13 @@ RSpec.describe Vajra do
 
   it 'builds a versioned ASCII header' do
     expect(described_class.header).to include('__      __')
-    expect(described_class.header).to include('v0.1.0')
+    expect(described_class.header).to include("v#{described_class::VERSION}")
   end
 
   it 'prints the header before delegating to the native start entrypoint' do
     allow(described_class).to receive(:native_start)
 
-    expect { described_class.start }.to output(include('v0.1.0')).to_stdout
+    expect { described_class.start }.to output(include("v#{described_class::VERSION}")).to_stdout
     expect(described_class).to have_received(:native_start)
   end
 

--- a/scripts/run-all
+++ b/scripts/run-all
@@ -10,8 +10,10 @@ SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 
 "${SCRIPT_DIR}/run-rubocop-all"
 "${SCRIPT_DIR}/run-reek-all"
+"${SCRIPT_DIR}/run-clint-all"
 "${SCRIPT_DIR}/run-rbs-all"
 "${SCRIPT_DIR}/run-rspec-unit-all"
 "${SCRIPT_DIR}/run-rspec-e2e-all"
+"${SCRIPT_DIR}/run-ctest-all"
 "${SCRIPT_DIR}/run-package-build-all"
 "${SCRIPT_DIR}/run-docs-build-all"

--- a/scripts/run-clint-all
+++ b/scripts/run-clint-all
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Copyright Codevedas Inc. 2025-present
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+. "${SCRIPT_DIR}/run-common"
+
+ruby_suites | while IFS= read -r suite_dir; do
+  run_optional_ruby_bin "${suite_dir}" "clint"
+done

--- a/scripts/run-ctest-all
+++ b/scripts/run-ctest-all
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Copyright Codevedas Inc. 2025-present
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+. "${SCRIPT_DIR}/run-common"
+
+ruby_suites | while IFS= read -r suite_dir; do
+  run_optional_ruby_bin "${suite_dir}" "ctest"
+done


### PR DESCRIPTION
- Refactored Server destructor to use close_listener_fd for better resource management.
- Introduced close_listener_fd method to handle listener socket closure and shutdown logic.
- Updated start method to utilize the new listener handling, improving shutdown reliability.
- Added idle_shutdown test to ensure clean shutdown behavior while idle and immediate restart capability.

closes: #24

