### PR TITLE
feat: implement lifecycle controller for server management

### DIFF
--- a/docs/pages/engineering-runtime.md
+++ b/docs/pages/engineering-runtime.md
@@ -36,7 +36,7 @@ The intended runtime state model is explicit and readable:
 - failed
 
 Supervision preserves those explicit transitions rather than burying lifecycle
-state in incidental flags.
+state in incidental flags or incidental file-descriptor ownership.
 
 ## Supervision Direction
 
@@ -63,6 +63,7 @@ The repo shape answers these questions:
 - where listener state lives
 - where diagnostics are emitted
 - where shutdown ownership transitions from Ruby to native code
+- where later supervision can observe lifecycle state without inferring it from listener flags
 
 The runtime also preserves a hard split between:
 

--- a/docs/pages/runtime-model.md
+++ b/docs/pages/runtime-model.md
@@ -43,8 +43,8 @@ clear and enforceable.
 ## Shutdown Model
 
 The native runtime installs signal handlers for `SIGINT` and `SIGTERM`. A stop
-request transitions the listener toward shutdown and releases the server
-instance from the process.
+request transitions the listener through an explicit draining state before the
+listener is released and the server instance leaves the process.
 
 ## Runtime Scope
 

--- a/gems/vajra/.rubocop.yml
+++ b/gems/vajra/.rubocop.yml
@@ -1,6 +1,7 @@
 plugins:
   - rubocop-rspec
   - rubocop-performance
+  - rubocop-thread_safety
   - rubocop-rake
 AllCops:
   NewCops: enable

--- a/gems/vajra/Gemfile
+++ b/gems/vajra/Gemfile
@@ -20,4 +20,5 @@ gem 'rubocop', '~> 1.72', require: false
 gem 'rubocop-performance', require: false
 gem 'rubocop-rake', require: false
 gem 'rubocop-rspec', require: false
+gem 'rubocop-thread_safety', '~> 0.7.2', require: false
 gem 'simplecov', '~> 0.22', require: false

--- a/gems/vajra/Gemfile.lock
+++ b/gems/vajra/Gemfile.lock
@@ -126,6 +126,10 @@ GEM
     rubocop-rspec (3.9.0)
       lint_roller (~> 1.1)
       rubocop (~> 1.81)
+    rubocop-thread_safety (0.7.3)
+      lint_roller (~> 1.1)
+      rubocop (~> 1.72, >= 1.72.1)
+      rubocop-ast (>= 1.44.0, < 2.0)
     ruby-progressbar (1.13.0)
     simplecov (0.22.0)
       docile (~> 1.1)
@@ -157,6 +161,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rake
   rubocop-rspec
+  rubocop-thread_safety (~> 0.7.2)
   simplecov (~> 0.22)
   vajra!
 

--- a/gems/vajra/bin/reek
+++ b/gems/vajra/bin/reek
@@ -8,13 +8,12 @@
 require 'pty'
 
 root_dir = File.expand_path('..', __dir__)
-Dir.chdir(root_dir)
 
 command = ['bundle', 'exec', 'reek', *ARGV]
 output = +''
 status = nil
 
-PTY.spawn(*command) do |reader, _writer, pid|
+PTY.spawn(*command, chdir: root_dir) do |reader, _writer, pid|
   reader.each { |line| output << line }
 rescue Errno::EIO
   nil

--- a/gems/vajra/ext/vajra/extconf.rb
+++ b/gems/vajra/ext/vajra/extconf.rb
@@ -9,7 +9,7 @@ require 'mkmf'
 
 append_cflags('-fvisibility=hidden')
 
-source_files = Dir.chdir(__dir__) { Dir.glob('**/*.cpp') }
+source_files = Dir.glob('**/*.cpp', base: __dir__)
 source_directories = source_files.map { |path| File.dirname(path) }.uniq.sort
 source_basenames = source_files.map { |path| File.basename(path) }.sort
 duplicate_basenames = source_basenames.tally.select { |_, count| count > 1 }.keys

--- a/gems/vajra/ext/vajra/lifecycle/lifecycle_controller.cpp
+++ b/gems/vajra/ext/vajra/lifecycle/lifecycle_controller.cpp
@@ -54,6 +54,9 @@ namespace Vajra
         std::lock_guard<std::mutex> lock(mutex_);
         if (state_ == State::draining)
         {
+          listener_owned_ = true;
+          port_ = port;
+          listener_fd_ = listener_fd;
           return false;
         }
 
@@ -153,6 +156,7 @@ namespace Vajra
     void Controller::finish_stop()
     {
       Snapshot snapshot_value;
+      bool notify_observer = false;
       {
         std::lock_guard<std::mutex> lock(mutex_);
         if (state_ == State::failed)
@@ -174,10 +178,14 @@ namespace Vajra
           pending_stop_before_start_ = false;
           listener_fd_ = -1;
           snapshot_value = snapshot_unlocked();
+          notify_observer = true;
         }
       }
 
-      notify(HookPoint::stop_completed, snapshot_value);
+      if (notify_observer)
+      {
+        notify(HookPoint::stop_completed, snapshot_value);
+      }
     }
 
     void Controller::mark_failed(StopReason reason)

--- a/gems/vajra/ext/vajra/lifecycle/lifecycle_controller.cpp
+++ b/gems/vajra/ext/vajra/lifecycle/lifecycle_controller.cpp
@@ -1,0 +1,235 @@
+// Copyright Codevedas Inc. 2025-present
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "lifecycle/lifecycle_controller.hpp"
+
+#include <stdexcept>
+#include <utility>
+
+namespace Vajra
+{
+  namespace lifecycle
+  {
+    Controller::Controller()
+        : state_(State::stopped),
+          last_stop_reason_(StopReason::none),
+          listener_owned_(false),
+          pending_stop_before_start_(false),
+          port_(-1),
+          listener_fd_(-1),
+          observer_()
+    {
+    }
+
+    void Controller::begin_startup()
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      if (state_ != State::stopped)
+      {
+        throw std::logic_error("lifecycle startup can only begin from stopped");
+      }
+
+      state_ = State::booting;
+      last_stop_reason_ = StopReason::none;
+      listener_owned_ = false;
+      pending_stop_before_start_ = false;
+      port_ = -1;
+      listener_fd_ = -1;
+    }
+
+    void Controller::mark_listening(int listener_fd, int port)
+    {
+      Snapshot snapshot_value;
+      {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (state_ != State::booting)
+        {
+          throw std::logic_error("lifecycle can only enter listening from booting");
+        }
+
+        state_ = State::listening;
+        listener_owned_ = true;
+        port_ = port;
+        listener_fd_ = listener_fd;
+        snapshot_value = snapshot_unlocked();
+      }
+
+      notify(HookPoint::boot_complete, snapshot_value);
+    }
+
+    void Controller::mark_serving()
+    {
+      Snapshot snapshot_value;
+      {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (state_ == State::serving || state_ == State::draining)
+        {
+          return;
+        }
+
+        if (state_ != State::listening)
+        {
+          throw std::logic_error("lifecycle can only enter serving from listening");
+        }
+
+        state_ = State::serving;
+        snapshot_value = snapshot_unlocked();
+      }
+
+      notify(HookPoint::serving_entered, snapshot_value);
+    }
+
+    void Controller::request_stop(StopReason reason)
+    {
+      if (reason == StopReason::none)
+      {
+        throw std::logic_error("lifecycle stop requests require an explicit reason");
+      }
+
+      Snapshot snapshot_value;
+      bool notify_observer = false;
+      {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (state_ == State::failed || state_ == State::draining)
+        {
+          if (last_stop_reason_ == StopReason::none)
+          {
+            last_stop_reason_ = reason;
+          }
+          return;
+        }
+
+        if (state_ == State::stopped)
+        {
+          if (last_stop_reason_ != StopReason::none)
+          {
+            return;
+          }
+
+          last_stop_reason_ = reason;
+          pending_stop_before_start_ = true;
+        }
+        else
+        {
+          if (state_ != State::booting && state_ != State::listening && state_ != State::serving)
+          {
+            throw std::logic_error("lifecycle stop can only be requested from active states");
+          }
+
+          state_ = State::draining;
+          last_stop_reason_ = reason;
+          pending_stop_before_start_ = false;
+          snapshot_value = snapshot_unlocked();
+          notify_observer = true;
+        }
+      }
+
+      if (notify_observer)
+      {
+        notify(HookPoint::drain_requested, snapshot_value);
+      }
+    }
+
+    void Controller::finish_stop()
+    {
+      Snapshot snapshot_value;
+      {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (state_ == State::failed)
+        {
+          listener_owned_ = false;
+          pending_stop_before_start_ = false;
+          listener_fd_ = -1;
+          snapshot_value = snapshot_unlocked();
+        }
+        else
+        {
+          if (state_ != State::listening && state_ != State::serving && state_ != State::draining)
+          {
+            throw std::logic_error("lifecycle stop can only finish from an active state");
+          }
+
+          state_ = State::stopped;
+          listener_owned_ = false;
+          pending_stop_before_start_ = false;
+          listener_fd_ = -1;
+          snapshot_value = snapshot_unlocked();
+        }
+      }
+
+      notify(HookPoint::stop_completed, snapshot_value);
+    }
+
+    void Controller::mark_failed(StopReason reason)
+    {
+      if (reason != StopReason::startup_failure && reason != StopReason::listener_failure)
+      {
+        throw std::logic_error("lifecycle failure requires a failure stop reason");
+      }
+
+      Snapshot snapshot_value;
+      {
+        std::lock_guard<std::mutex> lock(mutex_);
+        state_ = State::failed;
+        last_stop_reason_ = reason;
+        listener_owned_ = false;
+        pending_stop_before_start_ = false;
+        listener_fd_ = -1;
+        snapshot_value = snapshot_unlocked();
+      }
+
+      notify(HookPoint::failed_entered, snapshot_value);
+    }
+
+    Snapshot Controller::snapshot() const
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      return snapshot_unlocked();
+    }
+
+    bool Controller::consume_pending_stop_before_start()
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      if (state_ != State::stopped || !pending_stop_before_start_)
+      {
+        return false;
+      }
+
+      pending_stop_before_start_ = false;
+      return true;
+    }
+
+    Snapshot Controller::snapshot_unlocked() const
+    {
+      return Snapshot{
+          state_,
+          last_stop_reason_,
+          listener_owned_,
+          port_,
+          listener_fd_,
+      };
+    }
+
+    void Controller::set_observer(Observer observer)
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      observer_ = std::move(observer);
+    }
+
+    void Controller::notify(HookPoint hook_point, const Snapshot &snapshot_value)
+    {
+      Observer observer;
+      {
+        std::lock_guard<std::mutex> lock(mutex_);
+        observer = observer_;
+      }
+
+      if (observer)
+      {
+        observer(hook_point, snapshot_value);
+      }
+    }
+  }
+}

--- a/gems/vajra/ext/vajra/lifecycle/lifecycle_controller.cpp
+++ b/gems/vajra/ext/vajra/lifecycle/lifecycle_controller.cpp
@@ -23,9 +23,15 @@ namespace Vajra
     {
     }
 
-    void Controller::begin_startup()
+    bool Controller::begin_startup()
     {
       std::lock_guard<std::mutex> lock(mutex_);
+      if (state_ == State::stopped && pending_stop_before_start_)
+      {
+        pending_stop_before_start_ = false;
+        return false;
+      }
+
       if (state_ != State::stopped)
       {
         throw std::logic_error("lifecycle startup can only begin from stopped");
@@ -37,13 +43,20 @@ namespace Vajra
       pending_stop_before_start_ = false;
       port_ = -1;
       listener_fd_ = -1;
+      return true;
     }
 
-    void Controller::mark_listening(int listener_fd, int port)
+    bool Controller::mark_listening(int listener_fd, int port)
     {
       Snapshot snapshot_value;
+      bool notify_observer = false;
       {
         std::lock_guard<std::mutex> lock(mutex_);
+        if (state_ == State::draining)
+        {
+          return false;
+        }
+
         if (state_ != State::booting)
         {
           throw std::logic_error("lifecycle can only enter listening from booting");
@@ -54,9 +67,14 @@ namespace Vajra
         port_ = port;
         listener_fd_ = listener_fd;
         snapshot_value = snapshot_unlocked();
+        notify_observer = true;
       }
 
-      notify(HookPoint::boot_complete, snapshot_value);
+      if (notify_observer)
+      {
+        notify(HookPoint::boot_complete, snapshot_value);
+      }
+      return true;
     }
 
     void Controller::mark_serving()
@@ -187,18 +205,6 @@ namespace Vajra
     {
       std::lock_guard<std::mutex> lock(mutex_);
       return snapshot_unlocked();
-    }
-
-    bool Controller::consume_pending_stop_before_start()
-    {
-      std::lock_guard<std::mutex> lock(mutex_);
-      if (state_ != State::stopped || !pending_stop_before_start_)
-      {
-        return false;
-      }
-
-      pending_stop_before_start_ = false;
-      return true;
     }
 
     Snapshot Controller::snapshot_unlocked() const

--- a/gems/vajra/ext/vajra/lifecycle/lifecycle_controller.hpp
+++ b/gems/vajra/ext/vajra/lifecycle/lifecycle_controller.hpp
@@ -9,7 +9,6 @@
 #include <cstddef>
 #include <functional>
 #include <mutex>
-#include <optional>
 
 namespace Vajra
 {

--- a/gems/vajra/ext/vajra/lifecycle/lifecycle_controller.hpp
+++ b/gems/vajra/ext/vajra/lifecycle/lifecycle_controller.hpp
@@ -58,13 +58,12 @@ namespace Vajra
 
       Controller();
 
-      void begin_startup();
-      void mark_listening(int listener_fd, int port);
+      bool begin_startup();
+      bool mark_listening(int listener_fd, int port);
       void mark_serving();
       void request_stop(StopReason reason);
       void finish_stop();
       void mark_failed(StopReason reason);
-      bool consume_pending_stop_before_start();
 
       Snapshot snapshot() const;
       void set_observer(Observer observer);

--- a/gems/vajra/ext/vajra/lifecycle/lifecycle_controller.hpp
+++ b/gems/vajra/ext/vajra/lifecycle/lifecycle_controller.hpp
@@ -1,0 +1,89 @@
+// Copyright Codevedas Inc. 2025-present
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef VAJRA_LIFECYCLE_CONTROLLER_HPP
+#define VAJRA_LIFECYCLE_CONTROLLER_HPP
+
+#include <cstddef>
+#include <functional>
+#include <mutex>
+#include <optional>
+
+namespace Vajra
+{
+  namespace lifecycle
+  {
+    enum class State
+    {
+      booting,
+      listening,
+      serving,
+      draining,
+      stopped,
+      failed,
+    };
+
+    enum class StopReason
+    {
+      none,
+      programmatic_stop,
+      signal_shutdown,
+      startup_failure,
+      listener_failure,
+    };
+
+    enum class HookPoint
+    {
+      boot_complete,
+      serving_entered,
+      drain_requested,
+      stop_completed,
+      failed_entered,
+    };
+
+    struct Snapshot
+    {
+      State state;
+      StopReason last_stop_reason;
+      bool listener_owned;
+      int port;
+      int listener_fd;
+    };
+
+    class Controller
+    {
+    public:
+      using Observer = std::function<void(HookPoint, const Snapshot &)>;
+
+      Controller();
+
+      void begin_startup();
+      void mark_listening(int listener_fd, int port);
+      void mark_serving();
+      void request_stop(StopReason reason);
+      void finish_stop();
+      void mark_failed(StopReason reason);
+      bool consume_pending_stop_before_start();
+
+      Snapshot snapshot() const;
+      void set_observer(Observer observer);
+
+    private:
+      Snapshot snapshot_unlocked() const;
+      void notify(HookPoint hook_point, const Snapshot &snapshot);
+
+      mutable std::mutex mutex_;
+      State state_;
+      StopReason last_stop_reason_;
+      bool listener_owned_;
+      bool pending_stop_before_start_;
+      int port_;
+      int listener_fd_;
+      Observer observer_;
+    };
+  }
+}
+
+#endif

--- a/gems/vajra/ext/vajra/server.cpp
+++ b/gems/vajra/ext/vajra/server.cpp
@@ -16,6 +16,7 @@
 #include <sstream>
 #include <sys/socket.h>
 #include <unistd.h>
+#include <utility>
 
 namespace
 {
@@ -199,8 +200,6 @@ void Vajra::Server::start()
 
   port_ = binding.port;
   server_fd_.store(binding.fd);
-  lifecycle_.mark_listening(binding.fd, binding.port);
-
   if (lifecycle_.snapshot().state == lifecycle::State::draining || server_fd_.load() < 0)
   {
     close_listener_fd(false);
@@ -208,6 +207,7 @@ void Vajra::Server::start()
     return;
   }
 
+  lifecycle_.mark_listening(binding.fd, binding.port);
   log_listening_banner(port_);
 
   for (;;)
@@ -259,7 +259,7 @@ void Vajra::Server::start()
       lifecycle_.mark_serving();
     }
 
-  request_processor_.handle(client_fd);
+    request_processor_.handle(client_fd);
   }
 
   close_listener_fd(false);

--- a/gems/vajra/ext/vajra/server.cpp
+++ b/gems/vajra/ext/vajra/server.cpp
@@ -14,6 +14,7 @@
 #include <iomanip>
 #include <iostream>
 #include <sstream>
+#include <stdexcept>
 #include <sys/socket.h>
 #include <unistd.h>
 #include <utility>
@@ -178,14 +179,13 @@ void Vajra::Server::close_listener_fd(bool interrupt_accept)
 
 void Vajra::Server::start()
 {
-  if (lifecycle_.consume_pending_stop_before_start())
+  if (!lifecycle_.begin_startup())
   {
     close_listener_fd(false);
     return;
   }
 
   log_booting_event();
-  lifecycle_.begin_startup();
 
   listener::SocketBinding binding;
   try
@@ -200,14 +200,12 @@ void Vajra::Server::start()
 
   port_ = binding.port;
   server_fd_.store(binding.fd);
-  if (lifecycle_.snapshot().state == lifecycle::State::draining || server_fd_.load() < 0)
+  if (!lifecycle_.mark_listening(binding.fd, binding.port) || server_fd_.load() < 0)
   {
     close_listener_fd(false);
     lifecycle_.finish_stop();
     return;
   }
-
-  lifecycle_.mark_listening(binding.fd, binding.port);
   log_listening_banner(port_);
 
   for (;;)

--- a/gems/vajra/ext/vajra/server.cpp
+++ b/gems/vajra/ext/vajra/server.cpp
@@ -8,19 +8,150 @@
 
 #include <arpa/inet.h>
 #include <cerrno>
+#include <chrono>
 #include <cstring>
+#include <ctime>
+#include <iomanip>
 #include <iostream>
+#include <sstream>
 #include <sys/socket.h>
 #include <unistd.h>
+
+namespace
+{
+  const char *state_name(Vajra::lifecycle::State state)
+  {
+    switch (state)
+    {
+      case Vajra::lifecycle::State::booting:
+        return "booting";
+      case Vajra::lifecycle::State::listening:
+        return "listening";
+      case Vajra::lifecycle::State::serving:
+        return "serving";
+      case Vajra::lifecycle::State::draining:
+        return "draining";
+      case Vajra::lifecycle::State::stopped:
+        return "stopped";
+      case Vajra::lifecycle::State::failed:
+        return "failed";
+    }
+
+    throw std::logic_error("unknown lifecycle state");
+  }
+
+  const char *stop_reason_name(Vajra::lifecycle::StopReason reason)
+  {
+    switch (reason)
+    {
+      case Vajra::lifecycle::StopReason::none:
+        return "none";
+      case Vajra::lifecycle::StopReason::programmatic_stop:
+        return "programmatic_stop";
+      case Vajra::lifecycle::StopReason::signal_shutdown:
+        return "signal_shutdown";
+      case Vajra::lifecycle::StopReason::startup_failure:
+        return "startup_failure";
+      case Vajra::lifecycle::StopReason::listener_failure:
+        return "listener_failure";
+    }
+
+    throw std::logic_error("unknown lifecycle stop reason");
+  }
+
+  std::string utc_timestamp()
+  {
+    const auto now = std::chrono::system_clock::now();
+    const std::time_t now_time = std::chrono::system_clock::to_time_t(now);
+    std::tm utc_time{};
+    gmtime_r(&now_time, &utc_time);
+
+    std::ostringstream timestamp;
+    timestamp << std::put_time(&utc_time, "%Y-%m-%dT%H:%M:%SZ");
+    return timestamp.str();
+  }
+
+  void log_message(const char *event_type, const std::string &message, std::ostream &stream)
+  {
+    stream << "[Vajra][" << event_type << "] " << utc_timestamp() << ' ' << message << std::endl;
+  }
+
+  std::string lifecycle_details(const Vajra::lifecycle::Snapshot &snapshot)
+  {
+    std::ostringstream message;
+    message << "state=" << state_name(snapshot.state)
+            << " stop_reason=" << stop_reason_name(snapshot.last_stop_reason)
+            << " port=" << snapshot.port
+            << " listener_owned=" << (snapshot.listener_owned ? "true" : "false")
+            << " listener_fd=" << snapshot.listener_fd
+            << " mode=single_process"
+            << " worker_processes=0";
+    return message.str();
+  }
+
+  void log_runtime_event(const char *event_name, const Vajra::lifecycle::Snapshot &snapshot, std::ostream &stream)
+  {
+    std::ostringstream message;
+    message << "event=" << event_name << ' ' << lifecycle_details(snapshot);
+    log_message("lifecycle", message.str(), stream);
+  }
+
+  void log_booting_event()
+  {
+    const Vajra::lifecycle::Snapshot snapshot{
+        Vajra::lifecycle::State::booting,
+        Vajra::lifecycle::StopReason::none,
+        false,
+        -1,
+        -1,
+    };
+    log_runtime_event("booting", snapshot, std::cout);
+  }
+
+  void log_listening_banner(int port)
+  {
+    std::ostringstream message;
+    message << "listening on port " << port;
+    log_message("lifecycle", message.str(), std::cout);
+  }
+
+  void log_accept_failed(const char *error_message)
+  {
+    std::ostringstream message;
+    message << "accept failed: " << error_message;
+    log_message("error", message.str(), std::cerr);
+  }
+}
 
 Vajra::Server::Server(int port, std::size_t max_request_head_bytes)
     : port_(port),
       server_fd_(-1),
-      running_(false),
-      stop_requested_(false),
       listener_socket_(),
-      request_processor_(max_request_head_bytes)
+      request_processor_(max_request_head_bytes),
+      lifecycle_()
 {
+  set_lifecycle_observer([](lifecycle::HookPoint hook_point, const lifecycle::Snapshot &snapshot) {
+    switch (hook_point)
+    {
+      case lifecycle::HookPoint::boot_complete:
+        log_runtime_event("boot_complete", snapshot, std::cout);
+        return;
+      case lifecycle::HookPoint::serving_entered:
+        log_runtime_event("serving_entered", snapshot, std::cout);
+        return;
+      case lifecycle::HookPoint::drain_requested:
+        log_runtime_event("drain_requested", snapshot, std::cout);
+        return;
+      case lifecycle::HookPoint::stop_completed:
+        log_runtime_event("stop_completed", snapshot, std::cout);
+        return;
+      case lifecycle::HookPoint::failed_entered:
+        log_runtime_event("failed_entered", snapshot, std::cerr);
+        return;
+    }
+
+    throw std::logic_error("unknown lifecycle hook point");
+  });
 }
 
 Vajra::Server::~Server()
@@ -30,8 +161,6 @@ Vajra::Server::~Server()
 
 void Vajra::Server::close_listener_fd(bool interrupt_accept)
 {
-  running_ = false;
-
   const int listener_fd = server_fd_.exchange(-1);
   if (listener_fd < 0)
   {
@@ -48,35 +177,50 @@ void Vajra::Server::close_listener_fd(bool interrupt_accept)
 
 void Vajra::Server::start()
 {
-  if (stop_requested_.load())
+  if (lifecycle_.consume_pending_stop_before_start())
   {
+    close_listener_fd(false);
     return;
   }
 
-  const listener::SocketBinding binding = listener_socket_.open(port_);
+  log_booting_event();
+  lifecycle_.begin_startup();
+
+  listener::SocketBinding binding;
+  try
+  {
+    binding = listener_socket_.open(port_);
+  }
+  catch (...)
+  {
+    lifecycle_.mark_failed(lifecycle::StopReason::startup_failure);
+    throw;
+  }
+
   port_ = binding.port;
   server_fd_.store(binding.fd);
+  lifecycle_.mark_listening(binding.fd, binding.port);
 
-  if (stop_requested_.load())
+  if (lifecycle_.snapshot().state == lifecycle::State::draining || server_fd_.load() < 0)
   {
     close_listener_fd(false);
+    lifecycle_.finish_stop();
     return;
   }
 
-  running_ = true;
+  log_listening_banner(port_);
 
-  if (stop_requested_.load() || server_fd_.load() < 0)
+  for (;;)
   {
-    close_listener_fd(false);
-    return;
-  }
-
-  std::cout << "Vajra listening on port " << port_ << std::endl;
-
-  while (running_)
-  {
-    if (stop_requested_.load() || VajraNative::shutdown_requested())
+    const lifecycle::Snapshot snapshot = lifecycle_.snapshot();
+    if (snapshot.state == lifecycle::State::draining || snapshot.state == lifecycle::State::failed)
     {
+      break;
+    }
+
+    if (VajraNative::shutdown_requested())
+    {
+      lifecycle_.request_stop(lifecycle::StopReason::signal_shutdown);
       break;
     }
 
@@ -92,8 +236,12 @@ void Vajra::Server::start()
     const int client_fd = accept(listener_fd, reinterpret_cast<sockaddr *>(&client_addr), &client_len);
     if (client_fd < 0)
     {
-      if (!running_ || stop_requested_.load() || VajraNative::shutdown_requested())
+      if (lifecycle_.snapshot().state == lifecycle::State::draining || VajraNative::shutdown_requested())
       {
+        if (VajraNative::shutdown_requested())
+        {
+          lifecycle_.request_stop(lifecycle::StopReason::signal_shutdown);
+        }
         break;
       }
 
@@ -102,18 +250,34 @@ void Vajra::Server::start()
         continue;
       }
 
-      std::cerr << "accept failed: " << std::strerror(errno) << std::endl;
+      log_accept_failed(std::strerror(errno));
       continue;
     }
 
-    request_processor_.handle(client_fd);
+    if (lifecycle_.snapshot().state == lifecycle::State::listening)
+    {
+      lifecycle_.mark_serving();
+    }
+
+  request_processor_.handle(client_fd);
   }
 
   close_listener_fd(false);
+  lifecycle_.finish_stop();
 }
 
 void Vajra::Server::stop()
 {
-  stop_requested_ = true;
+  lifecycle_.request_stop(lifecycle::StopReason::programmatic_stop);
   close_listener_fd(true);
+}
+
+Vajra::lifecycle::Snapshot Vajra::Server::lifecycle_snapshot() const
+{
+  return lifecycle_.snapshot();
+}
+
+void Vajra::Server::set_lifecycle_observer(lifecycle::Controller::Observer observer)
+{
+  lifecycle_.set_observer(std::move(observer));
 }

--- a/gems/vajra/ext/vajra/server.hpp
+++ b/gems/vajra/ext/vajra/server.hpp
@@ -6,8 +6,11 @@
 #ifndef VAJRA_SERVER_HPP
 #define VAJRA_SERVER_HPP
 
-#include <atomic>
 #include <cstddef>
+#include <functional>
+#include <atomic>
+
+#include "lifecycle/lifecycle_controller.hpp"
 #include "listener/listener_socket.hpp"
 #include "request/request_head_error.hpp"
 #include "request/request_processor.hpp"
@@ -22,14 +25,15 @@ namespace Vajra
 
     void start();
     void stop();
+    lifecycle::Snapshot lifecycle_snapshot() const;
+    void set_lifecycle_observer(lifecycle::Controller::Observer observer);
 
   private:
     int port_;
     std::atomic<int> server_fd_;
-    std::atomic<bool> running_;
-    std::atomic<bool> stop_requested_;
     listener::Socket listener_socket_;
     request::RequestProcessor request_processor_;
+    lifecycle::Controller lifecycle_;
 
     void close_listener_fd(bool interrupt_accept);
   };

--- a/gems/vajra/lib/vajra.rb
+++ b/gems/vajra/lib/vajra.rb
@@ -39,7 +39,7 @@ module Vajra
            \__/ /_/   \_\ \___/  |_| \_\ /_/   \_\
       TEXT
 
-      "#{art}\nv#{Vajra::VERSION}\n"
+      "#{art}\nv#{Vajra::VERSION}\n\n"
     end
   end
 end

--- a/gems/vajra/spec/cpp/CMakeLists.txt
+++ b/gems/vajra/spec/cpp/CMakeLists.txt
@@ -13,11 +13,13 @@ add_executable(vajra_server_test
   ipc_frame_contract_test.cpp
   ipc_frame_header_test.cpp
   ipc_protocol_compatibility_test.cpp
+  lifecycle_controller_test.cpp
   server_lifecycle_test.cpp
   request_head_test.cpp
   response_test.cpp
   server_test.cpp
   ../../ext/vajra/ipc/protocol_contract.cpp
+  ../../ext/vajra/lifecycle/lifecycle_controller.cpp
   ../../ext/vajra/ipc/frame_header.cpp
   ../../ext/vajra/listener/listener_socket.cpp
   ../../ext/vajra/request/request_head_reader.cpp

--- a/gems/vajra/spec/cpp/lifecycle_controller_test.cpp
+++ b/gems/vajra/spec/cpp/lifecycle_controller_test.cpp
@@ -22,8 +22,10 @@ namespace VajraSpecCpp
         hook_points.push_back(hook_point);
       });
 
-      controller.begin_startup();
-      controller.mark_listening(7, 3000);
+      if (!controller.begin_startup() || !controller.mark_listening(7, 3000))
+      {
+        fail("lifecycle controller failed to begin normal startup");
+      }
       controller.mark_serving();
       controller.request_stop(Vajra::lifecycle::StopReason::programmatic_stop);
       controller.finish_stop();
@@ -61,7 +63,10 @@ namespace VajraSpecCpp
       {
       }
 
-      controller.begin_startup();
+      if (!controller.begin_startup())
+      {
+        fail("lifecycle controller refused valid startup transition");
+      }
 
       try
       {
@@ -76,7 +81,10 @@ namespace VajraSpecCpp
     void test_lifecycle_controller_preserves_failure_state()
     {
       Vajra::lifecycle::Controller controller;
-      controller.begin_startup();
+      if (!controller.begin_startup())
+      {
+        fail("lifecycle controller refused valid startup transition before failure");
+      }
       controller.mark_failed(Vajra::lifecycle::StopReason::startup_failure);
       controller.finish_stop();
 
@@ -92,8 +100,10 @@ namespace VajraSpecCpp
     void test_lifecycle_controller_stop_requests_are_idempotent()
     {
       Vajra::lifecycle::Controller controller;
-      controller.begin_startup();
-      controller.mark_listening(7, 3000);
+      if (!controller.begin_startup() || !controller.mark_listening(7, 3000))
+      {
+        fail("lifecycle controller failed to begin normal startup");
+      }
       controller.request_stop(Vajra::lifecycle::StopReason::signal_shutdown);
       controller.request_stop(Vajra::lifecycle::StopReason::programmatic_stop);
       controller.finish_stop();
@@ -108,8 +118,10 @@ namespace VajraSpecCpp
     void test_lifecycle_controller_ignores_serving_transition_after_drain_begins()
     {
       Vajra::lifecycle::Controller controller;
-      controller.begin_startup();
-      controller.mark_listening(7, 3000);
+      if (!controller.begin_startup() || !controller.mark_listening(7, 3000))
+      {
+        fail("lifecycle controller failed to begin normal startup");
+      }
       controller.request_stop(Vajra::lifecycle::StopReason::programmatic_stop);
       controller.mark_serving();
 
@@ -121,6 +133,28 @@ namespace VajraSpecCpp
       }
     }
 
+    void test_lifecycle_controller_rejects_listening_completion_after_drain_begins()
+    {
+      Vajra::lifecycle::Controller controller;
+      if (!controller.begin_startup())
+      {
+        fail("lifecycle controller refused valid startup transition");
+      }
+
+      controller.request_stop(Vajra::lifecycle::StopReason::programmatic_stop);
+      if (controller.mark_listening(7, 3000))
+      {
+        fail("lifecycle controller accepted listening after drain began");
+      }
+
+      const Vajra::lifecycle::Snapshot snapshot = controller.snapshot();
+      if (snapshot.state != Vajra::lifecycle::State::draining ||
+          snapshot.last_stop_reason != Vajra::lifecycle::StopReason::programmatic_stop)
+      {
+        fail("lifecycle controller did not preserve draining state when listening raced with stop");
+      }
+    }
+
     void test_lifecycle_controller_tracks_stop_before_start_separately_from_stopped_state()
     {
       Vajra::lifecycle::Controller controller;
@@ -129,20 +163,24 @@ namespace VajraSpecCpp
       const Vajra::lifecycle::Snapshot requested_snapshot = controller.snapshot();
       if (requested_snapshot.state != Vajra::lifecycle::State::stopped ||
           requested_snapshot.last_stop_reason != Vajra::lifecycle::StopReason::programmatic_stop ||
-          !controller.consume_pending_stop_before_start())
+          controller.begin_startup())
       {
         fail("lifecycle controller did not preserve stop-before-start request separately");
       }
 
-      if (controller.consume_pending_stop_before_start())
+      if (!controller.begin_startup())
       {
-        fail("lifecycle controller consumed stop-before-start request more than once");
+        fail("lifecycle controller did not allow startup after consuming stop-before-start request");
       }
 
       controller.request_stop(Vajra::lifecycle::StopReason::programmatic_stop);
-      if (controller.consume_pending_stop_before_start())
+      try
       {
-        fail("lifecycle controller re-entered pending stop after already-stopped stop request");
+        controller.begin_startup();
+        fail("lifecycle controller accepted startup while draining after repeated stop request");
+      }
+      catch (const std::logic_error &)
+      {
       }
     }
   }
@@ -154,6 +192,7 @@ namespace VajraSpecCpp
     test_lifecycle_controller_preserves_failure_state();
     test_lifecycle_controller_stop_requests_are_idempotent();
     test_lifecycle_controller_ignores_serving_transition_after_drain_begins();
+    test_lifecycle_controller_rejects_listening_completion_after_drain_begins();
     test_lifecycle_controller_tracks_stop_before_start_separately_from_stopped_state();
   }
 }

--- a/gems/vajra/spec/cpp/lifecycle_controller_test.cpp
+++ b/gems/vajra/spec/cpp/lifecycle_controller_test.cpp
@@ -1,0 +1,159 @@
+// Copyright Codevedas Inc. 2025-present
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "lifecycle/lifecycle_controller.hpp"
+#include "test_suites.hpp"
+#include "test_support.hpp"
+
+#include <stdexcept>
+#include <vector>
+
+namespace VajraSpecCpp
+{
+  namespace
+  {
+    void test_lifecycle_controller_tracks_normal_transitions()
+    {
+      Vajra::lifecycle::Controller controller;
+      std::vector<Vajra::lifecycle::HookPoint> hook_points;
+      controller.set_observer([&](Vajra::lifecycle::HookPoint hook_point, const Vajra::lifecycle::Snapshot &) {
+        hook_points.push_back(hook_point);
+      });
+
+      controller.begin_startup();
+      controller.mark_listening(7, 3000);
+      controller.mark_serving();
+      controller.request_stop(Vajra::lifecycle::StopReason::programmatic_stop);
+      controller.finish_stop();
+
+      const Vajra::lifecycle::Snapshot snapshot = controller.snapshot();
+      if (snapshot.state != Vajra::lifecycle::State::stopped ||
+          snapshot.last_stop_reason != Vajra::lifecycle::StopReason::programmatic_stop ||
+          snapshot.listener_owned)
+      {
+        fail("lifecycle controller did not preserve the expected stopped snapshot");
+      }
+
+      const std::vector<Vajra::lifecycle::HookPoint> expected_hooks = {
+          Vajra::lifecycle::HookPoint::boot_complete,
+          Vajra::lifecycle::HookPoint::serving_entered,
+          Vajra::lifecycle::HookPoint::drain_requested,
+          Vajra::lifecycle::HookPoint::stop_completed,
+      };
+      if (hook_points != expected_hooks)
+      {
+        fail("lifecycle controller did not emit the expected hook sequence");
+      }
+    }
+
+    void test_lifecycle_controller_rejects_invalid_transitions()
+    {
+      Vajra::lifecycle::Controller controller;
+
+      try
+      {
+        controller.mark_serving();
+        fail("lifecycle controller accepted serving before startup");
+      }
+      catch (const std::logic_error &)
+      {
+      }
+
+      controller.begin_startup();
+
+      try
+      {
+        controller.finish_stop();
+        fail("lifecycle controller accepted finish_stop before any stop request");
+      }
+      catch (const std::logic_error &)
+      {
+      }
+    }
+
+    void test_lifecycle_controller_preserves_failure_state()
+    {
+      Vajra::lifecycle::Controller controller;
+      controller.begin_startup();
+      controller.mark_failed(Vajra::lifecycle::StopReason::startup_failure);
+      controller.finish_stop();
+
+      const Vajra::lifecycle::Snapshot snapshot = controller.snapshot();
+      if (snapshot.state != Vajra::lifecycle::State::failed ||
+          snapshot.last_stop_reason != Vajra::lifecycle::StopReason::startup_failure ||
+          snapshot.listener_owned)
+      {
+        fail("lifecycle controller did not preserve failed terminal state");
+      }
+    }
+
+    void test_lifecycle_controller_stop_requests_are_idempotent()
+    {
+      Vajra::lifecycle::Controller controller;
+      controller.begin_startup();
+      controller.mark_listening(7, 3000);
+      controller.request_stop(Vajra::lifecycle::StopReason::signal_shutdown);
+      controller.request_stop(Vajra::lifecycle::StopReason::programmatic_stop);
+      controller.finish_stop();
+
+      const Vajra::lifecycle::Snapshot snapshot = controller.snapshot();
+      if (snapshot.last_stop_reason != Vajra::lifecycle::StopReason::signal_shutdown)
+      {
+        fail("lifecycle controller did not preserve the first stop reason");
+      }
+    }
+
+    void test_lifecycle_controller_ignores_serving_transition_after_drain_begins()
+    {
+      Vajra::lifecycle::Controller controller;
+      controller.begin_startup();
+      controller.mark_listening(7, 3000);
+      controller.request_stop(Vajra::lifecycle::StopReason::programmatic_stop);
+      controller.mark_serving();
+
+      const Vajra::lifecycle::Snapshot snapshot = controller.snapshot();
+      if (snapshot.state != Vajra::lifecycle::State::draining ||
+          snapshot.last_stop_reason != Vajra::lifecycle::StopReason::programmatic_stop)
+      {
+        fail("lifecycle controller did not preserve draining state when serving raced with stop");
+      }
+    }
+
+    void test_lifecycle_controller_tracks_stop_before_start_separately_from_stopped_state()
+    {
+      Vajra::lifecycle::Controller controller;
+      controller.request_stop(Vajra::lifecycle::StopReason::programmatic_stop);
+
+      const Vajra::lifecycle::Snapshot requested_snapshot = controller.snapshot();
+      if (requested_snapshot.state != Vajra::lifecycle::State::stopped ||
+          requested_snapshot.last_stop_reason != Vajra::lifecycle::StopReason::programmatic_stop ||
+          !controller.consume_pending_stop_before_start())
+      {
+        fail("lifecycle controller did not preserve stop-before-start request separately");
+      }
+
+      if (controller.consume_pending_stop_before_start())
+      {
+        fail("lifecycle controller consumed stop-before-start request more than once");
+      }
+
+      controller.request_stop(Vajra::lifecycle::StopReason::programmatic_stop);
+      if (controller.consume_pending_stop_before_start())
+      {
+        fail("lifecycle controller re-entered pending stop after already-stopped stop request");
+      }
+    }
+  }
+
+  void run_lifecycle_controller_tests()
+  {
+    test_lifecycle_controller_tracks_normal_transitions();
+    test_lifecycle_controller_rejects_invalid_transitions();
+    test_lifecycle_controller_preserves_failure_state();
+    test_lifecycle_controller_stop_requests_are_idempotent();
+    test_lifecycle_controller_ignores_serving_transition_after_drain_begins();
+    test_lifecycle_controller_tracks_stop_before_start_separately_from_stopped_state();
+  }
+}

--- a/gems/vajra/spec/cpp/lifecycle_controller_test.cpp
+++ b/gems/vajra/spec/cpp/lifecycle_controller_test.cpp
@@ -81,6 +81,10 @@ namespace VajraSpecCpp
     void test_lifecycle_controller_preserves_failure_state()
     {
       Vajra::lifecycle::Controller controller;
+      std::vector<Vajra::lifecycle::HookPoint> hook_points;
+      controller.set_observer([&](Vajra::lifecycle::HookPoint hook_point, const Vajra::lifecycle::Snapshot &) {
+        hook_points.push_back(hook_point);
+      });
       if (!controller.begin_startup())
       {
         fail("lifecycle controller refused valid startup transition before failure");
@@ -94,6 +98,14 @@ namespace VajraSpecCpp
           snapshot.listener_owned)
       {
         fail("lifecycle controller did not preserve failed terminal state");
+      }
+
+      const std::vector<Vajra::lifecycle::HookPoint> expected_hooks = {
+          Vajra::lifecycle::HookPoint::failed_entered,
+      };
+      if (hook_points != expected_hooks)
+      {
+        fail("lifecycle controller emitted stop_completed for failed terminal state");
       }
     }
 
@@ -149,9 +161,12 @@ namespace VajraSpecCpp
 
       const Vajra::lifecycle::Snapshot snapshot = controller.snapshot();
       if (snapshot.state != Vajra::lifecycle::State::draining ||
-          snapshot.last_stop_reason != Vajra::lifecycle::StopReason::programmatic_stop)
+          snapshot.last_stop_reason != Vajra::lifecycle::StopReason::programmatic_stop ||
+          snapshot.port != 3000 ||
+          snapshot.listener_fd != 7 ||
+          !snapshot.listener_owned)
       {
-        fail("lifecycle controller did not preserve draining state when listening raced with stop");
+        fail("lifecycle controller did not preserve bound listener diagnostics when listening raced with stop");
       }
     }
 

--- a/gems/vajra/spec/cpp/server_lifecycle_test.cpp
+++ b/gems/vajra/spec/cpp/server_lifecycle_test.cpp
@@ -9,12 +9,33 @@
 #include "test_support.hpp"
 
 #include <exception>
+#include <sstream>
 #include <thread>
 
 namespace VajraSpecCpp
 {
   namespace
   {
+    void expect_stopped_snapshot(
+        const Vajra::Server &server,
+        Vajra::lifecycle::StopReason expected_reason)
+    {
+      const Vajra::lifecycle::Snapshot snapshot = server.lifecycle_snapshot();
+      if (snapshot.state != Vajra::lifecycle::State::stopped ||
+          snapshot.last_stop_reason != expected_reason ||
+          snapshot.listener_owned)
+      {
+        std::ostringstream message;
+        message << "server lifecycle snapshot did not reach the expected stopped state"
+                << " state=" << static_cast<int>(snapshot.state)
+                << " stop_reason=" << static_cast<int>(snapshot.last_stop_reason)
+                << " listener_owned=" << snapshot.listener_owned
+                << " port=" << snapshot.port
+                << " listener_fd=" << snapshot.listener_fd;
+        fail(message.str());
+      }
+    }
+
     void test_start_and_stop_release_listener()
     {
       for (int attempt = 0; attempt < 10; ++attempt)
@@ -46,6 +67,7 @@ namespace VajraSpecCpp
           }
 
           assert_can_rebind(port);
+          expect_stopped_snapshot(server, Vajra::lifecycle::StopReason::programmatic_stop);
           return;
         }
         catch (...)
@@ -75,6 +97,71 @@ namespace VajraSpecCpp
       server.stop();
       server.start();
       assert_can_rebind(port);
+      expect_stopped_snapshot(server, Vajra::lifecycle::StopReason::programmatic_stop);
+    }
+
+    void test_repeated_start_stop_cycles_remain_reusable()
+    {
+      for (int cycle = 0; cycle < 3; ++cycle)
+      {
+        const int port = available_port();
+        Vajra::Server server(port, Vajra::request::kDefaultMaxRequestHeadBytes);
+        std::exception_ptr server_error;
+
+        std::thread server_thread([&]() {
+          try
+          {
+            server.start();
+          }
+          catch (...)
+          {
+            server_error = std::current_exception();
+          }
+        });
+
+        wait_until_listening(port);
+        server.stop();
+        server_thread.join();
+
+        if (server_error)
+        {
+          std::rethrow_exception(server_error);
+        }
+
+        assert_can_rebind(port);
+        expect_stopped_snapshot(server, Vajra::lifecycle::StopReason::programmatic_stop);
+      }
+    }
+
+    void test_repeated_stop_requests_are_idempotent()
+    {
+      const int port = available_port();
+      Vajra::Server server(port, Vajra::request::kDefaultMaxRequestHeadBytes);
+      std::exception_ptr server_error;
+
+      std::thread server_thread([&]() {
+        try
+        {
+          server.start();
+        }
+        catch (...)
+        {
+          server_error = std::current_exception();
+        }
+      });
+
+      wait_until_listening(port);
+      server.stop();
+      server.stop();
+      server_thread.join();
+
+      if (server_error)
+      {
+        std::rethrow_exception(server_error);
+      }
+
+      assert_can_rebind(port);
+      expect_stopped_snapshot(server, Vajra::lifecycle::StopReason::programmatic_stop);
     }
   }
 
@@ -82,5 +169,7 @@ namespace VajraSpecCpp
   {
     test_start_and_stop_release_listener();
     test_stop_before_start_exits_cleanly();
+    test_repeated_start_stop_cycles_remain_reusable();
+    test_repeated_stop_requests_are_idempotent();
   }
 }

--- a/gems/vajra/spec/cpp/server_test.cpp
+++ b/gems/vajra/spec/cpp/server_test.cpp
@@ -22,6 +22,7 @@ int main()
   try
   {
     VajraSpecCpp::run_ipc_contract_tests();
+    VajraSpecCpp::run_lifecycle_controller_tests();
     VajraSpecCpp::run_server_lifecycle_tests();
     VajraSpecCpp::run_request_head_tests();
     VajraSpecCpp::run_response_tests();

--- a/gems/vajra/spec/cpp/test_suites.hpp
+++ b/gems/vajra/spec/cpp/test_suites.hpp
@@ -12,6 +12,7 @@ namespace VajraSpecCpp
   void run_ipc_frame_contract_tests();
   void run_ipc_frame_header_tests();
   void run_ipc_protocol_compatibility_tests();
+  void run_lifecycle_controller_tests();
   void run_server_lifecycle_tests();
   void run_request_head_tests();
   void run_response_tests();

--- a/gems/vajra/spec/e2e/spec_helper.rb
+++ b/gems/vajra/spec/e2e/spec_helper.rb
@@ -40,7 +40,7 @@ module VajraE2EHelpers
   end
 
   def listener_banner(port)
-    "Vajra listening on port #{port}"
+    "listening on port #{port}"
   end
 
   def wait_for_banner(output)
@@ -49,7 +49,8 @@ module VajraE2EHelpers
         line = output.gets
         raise 'vajra exited before startup banner' if line.nil?
 
-        match = line.match(/Vajra listening on port (\d+)/)
+        match = line.match(/\[Vajra\]\[lifecycle\] .* listening on port (\d+)/) ||
+                line.match(/\[Vajra\]\[lifecycle\] .* event=boot_complete .* port=(\d+)/)
         return Integer(match[1]) if match
       end
     end

--- a/gems/vajra/spec/e2e/vajra/lifecycle_spec.rb
+++ b/gems/vajra/spec/e2e/vajra/lifecycle_spec.rb
@@ -13,6 +13,13 @@ RSpec.describe 'Vajra lifecycle', :e2e, :integration do # rubocop:disable RSpec/
 
     expect(shutdown[:exitstatus]).to eq(0)
     expect(shutdown[:output]).not_to include('accept failed')
+    expect(shutdown[:output]).to include(
+      '[Vajra][lifecycle]',
+      'event=drain_requested',
+      'event=stop_completed',
+      'mode=single_process',
+      'worker_processes=0'
+    )
 
     rebound_server = bind_port(port: shutdown[:port])
     rebound_server.close
@@ -23,11 +30,26 @@ RSpec.describe 'Vajra lifecycle', :e2e, :integration do # rubocop:disable RSpec/
     )
   end
 
+  it 'shuts down cleanly on SIGTERM and releases the listener immediately' do
+    shutdown = idle_shutdown(signal: 'TERM')
+
+    expect(shutdown[:exitstatus]).to eq(0)
+    expect(shutdown[:output]).not_to include('accept failed')
+
+    rebound_server = bind_port(port: shutdown[:port])
+    rebound_server.close
+  end
+
   it 'supports programmatic Vajra.stop and releases the listener' do
     shutdown = programmatic_shutdown
 
     expect(shutdown[:exitstatus]).to eq(0), shutdown[:output]
     expect(shutdown[:output]).not_to include('accept failed')
+    expect(shutdown[:output]).to include(
+      '[Vajra][lifecycle]',
+      'event=drain_requested',
+      'stop_reason=programmatic_stop'
+    )
   end
 
   it 'survives repeated process start stop thrashing and releases the listener every time' do

--- a/gems/vajra/spec/e2e/vajra/support/process_helpers.rb
+++ b/gems/vajra/spec/e2e/vajra/support/process_helpers.rb
@@ -65,11 +65,11 @@ module VajraE2EProcessHelpers
     end
   end
 
-  def idle_shutdown(port: disposable_listener_port)
+  def idle_shutdown(port: disposable_listener_port, signal: 'INT')
     Open3.popen2e(vajra_env(port:), *vajra_command, chdir: VajraE2EHelpers::PACKAGE_ROOT) do |_stdin, output, wait_thread|
       selected_port = wait_for_banner(output)
 
-      status = stop_process(wait_thread)
+      status = stop_process(wait_thread, signal:)
 
       { exitstatus: status.exitstatus, output: output.read, port: selected_port }
     ensure

--- a/gems/vajra/vajra.gemspec
+++ b/gems/vajra/vajra.gemspec
@@ -33,8 +33,8 @@ Gem::Specification.new do |spec|
   spec.metadata['rubygems_mfa_required'] = 'true'
   spec.bindir = 'exe'
   spec.executables = ['vajra']
-  spec.files = Dir.chdir(File.expand_path(__dir__)) do
-    Dir[
+  spec.files = Dir.glob(
+    [
       '{bin,exe,ext,lib,sig}/**/*',
       'LICENSE',
       'README.md',
@@ -43,8 +43,9 @@ Gem::Specification.new do |spec|
       '.reek.yml',
       '.rubocop.yml',
       '.ruby-version'
-    ]
-  end
+    ],
+    base: File.expand_path(__dir__)
+  )
   spec.require_paths = ['lib']
   spec.extensions = ['ext/vajra/extconf.rb']
 end


### PR DESCRIPTION
- Introduced a new lifecycle controller to manage server states (booting, listening, serving, draining, stopped, failed).
- Added methods to handle state transitions and notify observers of lifecycle events.
- Updated server implementation to utilize the lifecycle controller for managing its state and shutdown processes.
- Enhanced logging to provide detailed lifecycle event information.
- Added tests for lifecycle controller to ensure correct state transitions and idempotency of stop requests.
- Updated documentation to reflect changes in runtime state management and supervision direction.

closes: #39
closes: #40
closes: #41
closes: #42

