### PR TITLE
feat: implement request body transport for Rack integration

### DIFF
--- a/docs/pages/integration.md
+++ b/docs/pages/integration.md
@@ -66,7 +66,8 @@ The Rack environment translation contract is explicit:
   request bodies
 - the current request-body baseline accepts fixed-length bodies and HTTP/1.1
   chunked transfer coding, consumes trailers without surfacing them into the
-  Rack env, and still closes the connection after body-bearing requests
+  Rack env, enforces Vajra's native request-body size limits, and still closes
+  the connection after body-bearing requests
 
 ## Rails Integration
 

--- a/docs/pages/integration.md
+++ b/docs/pages/integration.md
@@ -62,8 +62,11 @@ The Rack environment translation contract is explicit:
 - request headers are translated into Rack-compatible environment keys, with
   `CONTENT_TYPE` and `CONTENT_LENGTH` preserved as CGI exceptions and all other
   request headers surfaced as `HTTP_*`
-- the initial Rack bridge keeps `rack.input` present as an empty placeholder
-  object until request-body transport is introduced as its own contract
+- `rack.input` is a buffered binary input object populated from supported
+  request bodies
+- the current request-body baseline accepts fixed-length bodies and HTTP/1.1
+  chunked transfer coding, consumes trailers without surfacing them into the
+  Rack env, and still closes the connection after body-bearing requests
 
 ## Rails Integration
 

--- a/gems/vajra/ext/vajra/rack/rack_request_executor.cpp
+++ b/gems/vajra/ext/vajra/rack/rack_request_executor.cpp
@@ -13,6 +13,7 @@
 #include "ruby/thread.h"
 
 #include <atomic>
+#include <limits>
 #include <mutex>
 #include <optional>
 #include <stdexcept>
@@ -60,9 +61,19 @@ namespace
     return std::string(RSTRING_PTR(value), static_cast<std::size_t>(RSTRING_LEN(value)));
   }
 
+  long ruby_string_length_for(const std::string &value)
+  {
+    if (value.size() > static_cast<std::size_t>(std::numeric_limits<long>::max()))
+    {
+      throw std::runtime_error("native request payload exceeds Ruby string length limit");
+    }
+
+    return static_cast<long>(value.size());
+  }
+
   VALUE ruby_binary_string_from(const std::string &value)
   {
-    VALUE ruby_string = rb_str_new(value.empty() ? "" : value.data(), static_cast<long>(value.size()));
+    VALUE ruby_string = rb_str_new(value.empty() ? "" : value.data(), ruby_string_length_for(value));
     rb_enc_associate_index(ruby_string, rb_ascii8bit_encindex());
     return ruby_string;
   }

--- a/gems/vajra/ext/vajra/rack/rack_request_executor.cpp
+++ b/gems/vajra/ext/vajra/rack/rack_request_executor.cpp
@@ -97,21 +97,32 @@ namespace
   VALUE protected_execute_rack_request(VALUE data)
   {
     auto *context = reinterpret_cast<ExecutionCallContext *>(data);
-    VALUE callback = Qnil;
+    try
     {
-      const std::lock_guard<std::mutex> callback_lock(rack_execution_callback_mutex);
-      callback = rack_execution_callback;
-    }
+      VALUE callback = Qnil;
+      {
+        const std::lock_guard<std::mutex> callback_lock(rack_execution_callback_mutex);
+        callback = rack_execution_callback;
+      }
 
-    if (NIL_P(callback))
+      if (NIL_P(callback))
+      {
+        return Qnil;
+      }
+
+      VALUE env_entries = ruby_env_entries_from(*context->env_entries);
+      VALUE request_body = ruby_binary_string_from(*context->request_body);
+      VALUE arguments[] = {env_entries, request_body};
+      return rb_proc_call(callback, rb_ary_new_from_values(2, arguments));
+    }
+    catch (const std::exception &error)
     {
-      return Qnil;
+      rb_raise(rb_eRuntimeError, "%s", error.what());
     }
-
-    VALUE env_entries = ruby_env_entries_from(*context->env_entries);
-    VALUE request_body = ruby_binary_string_from(*context->request_body);
-    VALUE arguments[] = {env_entries, request_body};
-    return rb_proc_call(callback, rb_ary_new_from_values(2, arguments));
+    catch (...)
+    {
+      rb_raise(rb_eRuntimeError, "Rack request execution failed with an unknown native error");
+    }
   }
 
   std::string exception_message(VALUE exception)

--- a/gems/vajra/ext/vajra/rack/rack_request_executor.cpp
+++ b/gems/vajra/ext/vajra/rack/rack_request_executor.cpp
@@ -30,6 +30,7 @@ namespace
   struct ExecutionCallContext
   {
     const std::vector<Vajra::request::RackEnvEntry> *env_entries;
+    const std::string *request_body;
     std::optional<Vajra::response::Response> response;
     std::string error_message;
   };
@@ -59,16 +60,21 @@ namespace
     return std::string(RSTRING_PTR(value), static_cast<std::size_t>(RSTRING_LEN(value)));
   }
 
+  VALUE ruby_binary_string_from(const std::string &value)
+  {
+    VALUE ruby_string = rb_str_new(value.empty() ? "" : value.data(), static_cast<long>(value.size()));
+    rb_enc_associate_index(ruby_string, rb_ascii8bit_encindex());
+    return ruby_string;
+  }
+
   VALUE ruby_env_entries_from(const std::vector<Vajra::request::RackEnvEntry> &env_entries)
   {
     VALUE ruby_entries = rb_ary_new_capa(static_cast<long>(env_entries.size()));
     for (const Vajra::request::RackEnvEntry &entry : env_entries)
     {
       VALUE pair = rb_ary_new_capa(2);
-      VALUE key = rb_str_new(entry.key.data(), static_cast<long>(entry.key.size()));
-      VALUE value = rb_str_new(entry.value.data(), static_cast<long>(entry.value.size()));
-      rb_enc_associate_index(key, rb_ascii8bit_encindex());
-      rb_enc_associate_index(value, rb_ascii8bit_encindex());
+      VALUE key = ruby_binary_string_from(entry.key);
+      VALUE value = ruby_binary_string_from(entry.value);
       rb_ary_push(pair, key);
       rb_ary_push(pair, value);
       rb_ary_push(ruby_entries, pair);
@@ -92,8 +98,9 @@ namespace
     }
 
     VALUE env_entries = ruby_env_entries_from(*context->env_entries);
-    VALUE arguments[] = {env_entries};
-    return rb_proc_call(callback, rb_ary_new_from_values(1, arguments));
+    VALUE request_body = ruby_binary_string_from(*context->request_body);
+    VALUE arguments[] = {env_entries, request_body};
+    return rb_proc_call(callback, rb_ary_new_from_values(2, arguments));
   }
 
   std::string exception_message(VALUE exception)
@@ -362,30 +369,6 @@ namespace
 
     return nullptr;
   }
-  void ensure_bodyless_rack_request(const Vajra::request::RequestContext &request_context)
-  {
-    for (const Vajra::request::ParsedHeader &header : request_context.request.headers)
-    {
-      if (Vajra::request::ascii_case_insensitive_equal(header.name, "Transfer-Encoding"))
-      {
-        throw Vajra::request::bad_request_error(
-            "Rack request execution does not support request bodies until body transport is implemented");
-      }
-
-      if (!Vajra::request::ascii_case_insensitive_equal(header.name, "Content-Length"))
-      {
-        continue;
-      }
-
-      if (Vajra::request::content_length_is_zero(header.value))
-      {
-        continue;
-      }
-
-      throw Vajra::request::bad_request_error(
-          "Rack request execution does not support request bodies until body transport is implemented");
-    }
-  }
 }
 
 void Vajra::rack::initialize_rack_execution_bridge()
@@ -411,10 +394,9 @@ std::optional<Vajra::response::Response> Vajra::rack::RackRequestExecutor::execu
     return std::nullopt;
   }
 
-  ensure_bodyless_rack_request(request_context);
   request::RackEnvBuilder builder;
   const std::vector<request::RackEnvEntry> env_entries = builder.build(request_context);
-  ExecutionCallContext context{&env_entries, std::nullopt, ""};
+  ExecutionCallContext context{&env_entries, &request_context.request_body, std::nullopt, ""};
   rb_thread_call_with_gvl(execute_rack_request_with_gvl, &context);
 
   if (!context.error_message.empty())

--- a/gems/vajra/ext/vajra/request/request_body_reader.cpp
+++ b/gems/vajra/ext/vajra/request/request_body_reader.cpp
@@ -40,6 +40,16 @@ namespace
     throw Vajra::request::bad_request_error(bad_request_message_for_body_read());
   }
 
+  [[noreturn]] void raise_request_body_too_large()
+  {
+    throw Vajra::request::bad_request_error("request body exceeds maximum size");
+  }
+
+  [[noreturn]] void raise_request_body_metadata_too_large()
+  {
+    throw Vajra::request::bad_request_error("request body metadata exceeds maximum size");
+  }
+
   std::size_t parse_decimal_content_length(const std::string &value)
   {
     const std::string normalized = Vajra::request::strip_http_whitespace(value);
@@ -152,6 +162,44 @@ namespace
     return BodyReadPlan{BodyFraming::content_length, content_length};
   }
 
+  std::size_t unread_bytes(const std::string &buffer, std::size_t cursor)
+  {
+    return buffer.size() - cursor;
+  }
+
+  void compact_consumed_prefix(std::string &buffer, std::size_t &cursor)
+  {
+    if (cursor == 0)
+    {
+      return;
+    }
+
+    if (cursor >= buffer.size())
+    {
+      buffer.clear();
+      cursor = 0;
+      return;
+    }
+
+    if (cursor < 4096 && cursor * 2 < buffer.size())
+    {
+      return;
+    }
+
+    buffer.erase(0, cursor);
+    cursor = 0;
+  }
+
+  std::string unread_suffix(std::string &buffer, std::size_t cursor)
+  {
+    if (cursor == 0)
+    {
+      return std::move(buffer);
+    }
+
+    return buffer.substr(cursor);
+  }
+
   void append_socket_bytes(std::string &buffer, int client_fd)
   {
     char chunk[4096];
@@ -179,24 +227,30 @@ namespace
     }
   }
 
-  void ensure_buffer_bytes(std::string &buffer, std::size_t expected_size, int client_fd)
+  void ensure_buffer_bytes(std::string &buffer, std::size_t cursor, std::size_t expected_size, int client_fd)
   {
-    while (buffer.size() < expected_size)
+    while (unread_bytes(buffer, cursor) < expected_size)
     {
       append_socket_bytes(buffer, client_fd);
     }
   }
 
-  std::string read_line(std::string &buffer, int client_fd)
+  std::string read_line(std::string &buffer, std::size_t &cursor, int client_fd, std::size_t max_line_bytes)
   {
     while (true)
     {
-      const std::size_t line_end = buffer.find("\r\n");
+      const std::size_t line_end = buffer.find("\r\n", cursor);
       if (line_end != std::string::npos)
       {
-        const std::string line = buffer.substr(0, line_end);
-        buffer.erase(0, line_end + 2);
+        const std::string line = buffer.substr(cursor, line_end - cursor);
+        cursor = line_end + 2;
+        compact_consumed_prefix(buffer, cursor);
         return line;
+      }
+
+      if (unread_bytes(buffer, cursor) > max_line_bytes)
+      {
+        raise_request_body_metadata_too_large();
       }
 
       append_socket_bytes(buffer, client_fd);
@@ -259,11 +313,11 @@ namespace
     }
   }
 
-  void consume_trailers(std::string &buffer, int client_fd)
+  void consume_trailers(std::string &buffer, std::size_t &cursor, int client_fd, std::size_t max_trailer_line_bytes)
   {
     while (true)
     {
-      const std::string trailer_line = read_line(buffer, client_fd);
+      const std::string trailer_line = read_line(buffer, cursor, client_fd, max_trailer_line_bytes);
       if (trailer_line.empty())
       {
         return;
@@ -276,35 +330,56 @@ namespace
   Vajra::request::BodyReadResult read_content_length_body(
       int client_fd,
       std::size_t content_length,
-      std::string buffered_bytes)
+      std::string buffered_bytes,
+      std::size_t max_request_body_bytes)
   {
-    ensure_buffer_bytes(buffered_bytes, content_length, client_fd);
+    if (content_length > max_request_body_bytes)
+    {
+      raise_request_body_too_large();
+    }
+
+    const std::size_t body_start = 0;
+    ensure_buffer_bytes(buffered_bytes, body_start, content_length, client_fd);
     return Vajra::request::BodyReadResult{
-        buffered_bytes.substr(0, content_length),
-        ""};
+        buffered_bytes.substr(body_start, content_length),
+        buffered_bytes.substr(body_start + content_length)};
   }
 
-  Vajra::request::BodyReadResult read_chunked_body(int client_fd, std::string buffered_bytes)
+  Vajra::request::BodyReadResult read_chunked_body(
+      int client_fd,
+      std::string buffered_bytes,
+      std::size_t max_request_body_bytes,
+      std::size_t max_chunk_line_bytes,
+      std::size_t max_trailer_line_bytes)
   {
     std::string body;
+    std::size_t cursor = 0;
 
     while (true)
     {
-      const std::size_t chunk_size = parse_chunk_size(read_line(buffered_bytes, client_fd));
+      const std::size_t chunk_size = parse_chunk_size(
+          read_line(buffered_bytes, cursor, client_fd, max_chunk_line_bytes));
       if (chunk_size == 0)
       {
-        consume_trailers(buffered_bytes, client_fd);
-        return Vajra::request::BodyReadResult{body, ""};
+        consume_trailers(buffered_bytes, cursor, client_fd, max_trailer_line_bytes);
+        return Vajra::request::BodyReadResult{body, unread_suffix(buffered_bytes, cursor)};
       }
 
-      ensure_buffer_bytes(buffered_bytes, chunk_size + 2, client_fd);
-      body.append(buffered_bytes.data(), chunk_size);
-      if (buffered_bytes[chunk_size] != '\r' || buffered_bytes[chunk_size + 1] != '\n')
+      if (chunk_size > max_request_body_bytes - body.size())
+      {
+        raise_request_body_too_large();
+      }
+
+      ensure_buffer_bytes(buffered_bytes, cursor, chunk_size + 2, client_fd);
+      body.append(buffered_bytes.data() + cursor, chunk_size);
+      cursor += chunk_size;
+      if (buffered_bytes[cursor] != '\r' || buffered_bytes[cursor + 1] != '\n')
       {
         raise_invalid_body_read();
       }
 
-      buffered_bytes.erase(0, chunk_size + 2);
+      cursor += 2;
+      compact_consumed_prefix(buffered_bytes, cursor);
     }
   }
 }
@@ -321,9 +396,18 @@ Vajra::request::BodyReadResult Vajra::request::RequestBodyReader::read(
     case BodyFraming::none:
       return BodyReadResult{"", std::move(buffered_bytes)};
     case BodyFraming::content_length:
-      return read_content_length_body(client_fd, plan.content_length, std::move(buffered_bytes));
+      return read_content_length_body(
+          client_fd,
+          plan.content_length,
+          std::move(buffered_bytes),
+          max_request_body_bytes_);
     case BodyFraming::chunked:
-      return read_chunked_body(client_fd, std::move(buffered_bytes));
+      return read_chunked_body(
+          client_fd,
+          std::move(buffered_bytes),
+          max_request_body_bytes_,
+          max_chunk_line_bytes_,
+          max_trailer_line_bytes_);
   }
 
   raise_invalid_body_read();

--- a/gems/vajra/ext/vajra/request/request_body_reader.cpp
+++ b/gems/vajra/ext/vajra/request/request_body_reader.cpp
@@ -252,13 +252,20 @@ namespace
       const std::size_t line_end = buffer.find("\r\n", cursor);
       if (line_end != std::string::npos)
       {
+        if (line_end - cursor > max_line_bytes)
+        {
+          raise_request_body_metadata_too_large();
+        }
+
         const std::string line = buffer.substr(cursor, line_end - cursor);
         cursor = line_end + 2;
         compact_consumed_prefix(buffer, cursor);
         return line;
       }
 
-      if (unread_bytes(buffer, cursor) >= max_line_bytes)
+      const std::size_t buffered_line_bytes = unread_bytes(buffer, cursor);
+      if (buffered_line_bytes > max_line_bytes + 1 ||
+          (buffered_line_bytes == max_line_bytes + 1 && buffer[cursor + buffered_line_bytes - 1] != '\r'))
       {
         raise_request_body_metadata_too_large();
       }

--- a/gems/vajra/ext/vajra/request/request_body_reader.cpp
+++ b/gems/vajra/ext/vajra/request/request_body_reader.cpp
@@ -13,6 +13,7 @@
 #include <limits>
 #include <string>
 #include <sys/socket.h>
+#include <utility>
 #include <vector>
 
 namespace
@@ -410,21 +411,21 @@ Vajra::request::BodyReadResult Vajra::request::RequestBodyReader::read(
 
   switch (plan.framing)
   {
-    case BodyFraming::none:
-      return BodyReadResult{"", std::move(buffered_bytes)};
-    case BodyFraming::content_length:
-      return read_content_length_body(
-          client_fd,
-          plan.content_length,
-          std::move(buffered_bytes),
-          max_request_body_bytes_);
-    case BodyFraming::chunked:
-      return read_chunked_body(
-          client_fd,
-          std::move(buffered_bytes),
-          max_request_body_bytes_,
-          max_chunk_line_bytes_,
-          max_trailer_line_bytes_);
+  case BodyFraming::none:
+    return BodyReadResult{"", std::move(buffered_bytes)};
+  case BodyFraming::content_length:
+    return read_content_length_body(
+        client_fd,
+        plan.content_length,
+        std::move(buffered_bytes),
+        max_request_body_bytes_);
+  case BodyFraming::chunked:
+    return read_chunked_body(
+        client_fd,
+        std::move(buffered_bytes),
+        max_request_body_bytes_,
+        max_chunk_line_bytes_,
+        max_trailer_line_bytes_);
   }
 
   raise_invalid_body_read();

--- a/gems/vajra/ext/vajra/request/request_body_reader.cpp
+++ b/gems/vajra/ext/vajra/request/request_body_reader.cpp
@@ -1,0 +1,330 @@
+// Copyright Codevedas Inc. 2025-present
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "request_body_reader.hpp"
+
+#include "http_field_utils.hpp"
+#include "request_head_error.hpp"
+
+#include <cerrno>
+#include <cstdlib>
+#include <limits>
+#include <string>
+#include <sys/socket.h>
+#include <vector>
+
+namespace
+{
+  enum class BodyFraming
+  {
+    none,
+    content_length,
+    chunked
+  };
+
+  struct BodyReadPlan
+  {
+    BodyFraming framing;
+    std::size_t content_length = 0;
+  };
+
+  std::string bad_request_message_for_body_read()
+  {
+    return "request body framing is invalid";
+  }
+
+  [[noreturn]] void raise_invalid_body_read()
+  {
+    throw Vajra::request::bad_request_error(bad_request_message_for_body_read());
+  }
+
+  std::size_t parse_decimal_content_length(const std::string &value)
+  {
+    const std::string normalized = Vajra::request::strip_http_whitespace(value);
+    if (normalized.empty())
+    {
+      raise_invalid_body_read();
+    }
+
+    std::size_t content_length = 0;
+    for (const char character : normalized)
+    {
+      if (character < '0' || character > '9')
+      {
+        raise_invalid_body_read();
+      }
+
+      const std::size_t digit = static_cast<std::size_t>(character - '0');
+      if (content_length > (std::numeric_limits<std::size_t>::max() - digit) / 10)
+      {
+        raise_invalid_body_read();
+      }
+
+      content_length = content_length * 10 + digit;
+    }
+
+    return content_length;
+  }
+
+  std::vector<std::string> transfer_encoding_tokens(const std::string &value)
+  {
+    std::vector<std::string> tokens;
+    std::size_t cursor = 0;
+
+    while (cursor <= value.size())
+    {
+      const std::size_t delimiter = value.find(',', cursor);
+      const std::string token =
+          Vajra::request::strip_http_whitespace(value.substr(cursor, delimiter - cursor));
+      if (token.empty())
+      {
+        raise_invalid_body_read();
+      }
+
+      tokens.push_back(token);
+      if (delimiter == std::string::npos)
+      {
+        break;
+      }
+
+      cursor = delimiter + 1;
+    }
+
+    return tokens;
+  }
+
+  BodyReadPlan body_read_plan_for(const Vajra::request::ParsedRequest &request)
+  {
+    bool saw_content_length = false;
+    bool saw_transfer_encoding = false;
+    std::size_t content_length = 0;
+    std::vector<std::string> transfer_encodings;
+
+    for (const Vajra::request::ParsedHeader &header : request.headers)
+    {
+      if (Vajra::request::ascii_case_insensitive_equal(header.name, "Content-Length"))
+      {
+        if (saw_content_length)
+        {
+          raise_invalid_body_read();
+        }
+
+        content_length = parse_decimal_content_length(header.value);
+        saw_content_length = true;
+        continue;
+      }
+
+      if (Vajra::request::ascii_case_insensitive_equal(header.name, "Transfer-Encoding"))
+      {
+        if (saw_transfer_encoding)
+        {
+          raise_invalid_body_read();
+        }
+
+        transfer_encodings = transfer_encoding_tokens(header.value);
+        saw_transfer_encoding = true;
+      }
+    }
+
+    if (saw_content_length && saw_transfer_encoding)
+    {
+      raise_invalid_body_read();
+    }
+
+    if (saw_transfer_encoding)
+    {
+      if (transfer_encodings.size() != 1 ||
+          !Vajra::request::ascii_case_insensitive_equal(transfer_encodings[0], "chunked"))
+      {
+        raise_invalid_body_read();
+      }
+
+      return BodyReadPlan{BodyFraming::chunked, 0};
+    }
+
+    if (!saw_content_length || content_length == 0)
+    {
+      return BodyReadPlan{BodyFraming::none, 0};
+    }
+
+    return BodyReadPlan{BodyFraming::content_length, content_length};
+  }
+
+  void append_socket_bytes(std::string &buffer, int client_fd)
+  {
+    char chunk[4096];
+
+    for (;;)
+    {
+      const ssize_t bytes_read = recv(client_fd, chunk, sizeof(chunk), 0);
+      if (bytes_read < 0)
+      {
+        if (errno == EINTR)
+        {
+          continue;
+        }
+
+        raise_invalid_body_read();
+      }
+
+      if (bytes_read == 0)
+      {
+        raise_invalid_body_read();
+      }
+
+      buffer.append(chunk, static_cast<std::size_t>(bytes_read));
+      return;
+    }
+  }
+
+  void ensure_buffer_bytes(std::string &buffer, std::size_t expected_size, int client_fd)
+  {
+    while (buffer.size() < expected_size)
+    {
+      append_socket_bytes(buffer, client_fd);
+    }
+  }
+
+  std::string read_line(std::string &buffer, int client_fd)
+  {
+    while (true)
+    {
+      const std::size_t line_end = buffer.find("\r\n");
+      if (line_end != std::string::npos)
+      {
+        const std::string line = buffer.substr(0, line_end);
+        buffer.erase(0, line_end + 2);
+        return line;
+      }
+
+      append_socket_bytes(buffer, client_fd);
+    }
+  }
+
+  std::size_t parse_chunk_size(const std::string &line)
+  {
+    const std::size_t extension_delimiter = line.find(';');
+    const std::string size_token = Vajra::request::strip_http_whitespace(line.substr(0, extension_delimiter));
+    if (size_token.empty())
+    {
+      raise_invalid_body_read();
+    }
+
+    std::size_t chunk_size = 0;
+    for (const char character : size_token)
+    {
+      std::size_t digit = 0;
+      if (character >= '0' && character <= '9')
+      {
+        digit = static_cast<std::size_t>(character - '0');
+      }
+      else if (character >= 'a' && character <= 'f')
+      {
+        digit = static_cast<std::size_t>(character - 'a' + 10);
+      }
+      else if (character >= 'A' && character <= 'F')
+      {
+        digit = static_cast<std::size_t>(character - 'A' + 10);
+      }
+      else
+      {
+        raise_invalid_body_read();
+      }
+
+      if (chunk_size > (std::numeric_limits<std::size_t>::max() - digit) / 16)
+      {
+        raise_invalid_body_read();
+      }
+
+      chunk_size = chunk_size * 16 + digit;
+    }
+
+    return chunk_size;
+  }
+
+  void validate_trailer_line(const std::string &line)
+  {
+    const std::size_t delimiter = line.find(':');
+    if (delimiter == std::string::npos || delimiter == 0)
+    {
+      raise_invalid_body_read();
+    }
+
+    const std::string name = line.substr(0, delimiter);
+    if (name.find_first_of(" \t") != std::string::npos)
+    {
+      raise_invalid_body_read();
+    }
+  }
+
+  void consume_trailers(std::string &buffer, int client_fd)
+  {
+    while (true)
+    {
+      const std::string trailer_line = read_line(buffer, client_fd);
+      if (trailer_line.empty())
+      {
+        return;
+      }
+
+      validate_trailer_line(trailer_line);
+    }
+  }
+
+  Vajra::request::BodyReadResult read_content_length_body(
+      int client_fd,
+      std::size_t content_length,
+      std::string buffered_bytes)
+  {
+    ensure_buffer_bytes(buffered_bytes, content_length, client_fd);
+    return Vajra::request::BodyReadResult{
+        buffered_bytes.substr(0, content_length),
+        ""};
+  }
+
+  Vajra::request::BodyReadResult read_chunked_body(int client_fd, std::string buffered_bytes)
+  {
+    std::string body;
+
+    while (true)
+    {
+      const std::size_t chunk_size = parse_chunk_size(read_line(buffered_bytes, client_fd));
+      if (chunk_size == 0)
+      {
+        consume_trailers(buffered_bytes, client_fd);
+        return Vajra::request::BodyReadResult{body, ""};
+      }
+
+      ensure_buffer_bytes(buffered_bytes, chunk_size + 2, client_fd);
+      body.append(buffered_bytes.data(), chunk_size);
+      if (buffered_bytes[chunk_size] != '\r' || buffered_bytes[chunk_size + 1] != '\n')
+      {
+        raise_invalid_body_read();
+      }
+
+      buffered_bytes.erase(0, chunk_size + 2);
+    }
+  }
+}
+
+Vajra::request::BodyReadResult Vajra::request::RequestBodyReader::read(
+    int client_fd,
+    const ParsedRequest &request,
+    std::string buffered_bytes) const
+{
+  const BodyReadPlan plan = body_read_plan_for(request);
+
+  switch (plan.framing)
+  {
+    case BodyFraming::none:
+      return BodyReadResult{"", std::move(buffered_bytes)};
+    case BodyFraming::content_length:
+      return read_content_length_body(client_fd, plan.content_length, std::move(buffered_bytes));
+    case BodyFraming::chunked:
+      return read_chunked_body(client_fd, std::move(buffered_bytes));
+  }
+
+  raise_invalid_body_read();
+}

--- a/gems/vajra/ext/vajra/request/request_body_reader.cpp
+++ b/gems/vajra/ext/vajra/request/request_body_reader.cpp
@@ -50,6 +50,11 @@ namespace
     throw Vajra::request::bad_request_error("request body metadata exceeds maximum size");
   }
 
+  [[noreturn]] void raise_incomplete_body_read()
+  {
+    throw Vajra::request::BodyReadIncompleteError();
+  }
+
   std::size_t parse_decimal_content_length(const std::string &value)
   {
     const std::string normalized = Vajra::request::strip_http_whitespace(value);
@@ -214,12 +219,17 @@ namespace
           continue;
         }
 
+        if (errno == EAGAIN || errno == EWOULDBLOCK)
+        {
+          raise_incomplete_body_read();
+        }
+
         raise_invalid_body_read();
       }
 
       if (bytes_read == 0)
       {
-        raise_invalid_body_read();
+        raise_incomplete_body_read();
       }
 
       buffer.append(chunk, static_cast<std::size_t>(bytes_read));

--- a/gems/vajra/ext/vajra/request/request_body_reader.cpp
+++ b/gems/vajra/ext/vajra/request/request_body_reader.cpp
@@ -224,7 +224,7 @@ namespace
           raise_incomplete_body_read();
         }
 
-        raise_invalid_body_read();
+        raise_incomplete_body_read();
       }
 
       if (bytes_read == 0)

--- a/gems/vajra/ext/vajra/request/request_body_reader.cpp
+++ b/gems/vajra/ext/vajra/request/request_body_reader.cpp
@@ -248,7 +248,7 @@ namespace
         return line;
       }
 
-      if (unread_bytes(buffer, cursor) > max_line_bytes)
+      if (unread_bytes(buffer, cursor) >= max_line_bytes)
       {
         raise_request_body_metadata_too_large();
       }

--- a/gems/vajra/ext/vajra/request/request_body_reader.hpp
+++ b/gems/vajra/ext/vajra/request/request_body_reader.hpp
@@ -8,12 +8,17 @@
 
 #include "request_head_types.hpp"
 
+#include <cstddef>
 #include <string>
 
 namespace Vajra
 {
   namespace request
   {
+    constexpr std::size_t kDefaultMaxRequestBodyBytes = 16 * 1024 * 1024;
+    constexpr std::size_t kDefaultMaxChunkLineBytes = 8 * 1024;
+    constexpr std::size_t kDefaultMaxTrailerLineBytes = 8 * 1024;
+
     struct BodyReadResult
     {
       std::string body;
@@ -23,10 +28,25 @@ namespace Vajra
     class RequestBodyReader
     {
     public:
+      explicit RequestBodyReader(
+          std::size_t max_request_body_bytes = kDefaultMaxRequestBodyBytes,
+          std::size_t max_chunk_line_bytes = kDefaultMaxChunkLineBytes,
+          std::size_t max_trailer_line_bytes = kDefaultMaxTrailerLineBytes)
+          : max_request_body_bytes_(max_request_body_bytes),
+            max_chunk_line_bytes_(max_chunk_line_bytes),
+            max_trailer_line_bytes_(max_trailer_line_bytes)
+      {
+      }
+
       BodyReadResult read(
           int client_fd,
           const ParsedRequest &request,
           std::string buffered_bytes = "") const;
+
+    private:
+      std::size_t max_request_body_bytes_;
+      std::size_t max_chunk_line_bytes_;
+      std::size_t max_trailer_line_bytes_;
     };
   }
 }

--- a/gems/vajra/ext/vajra/request/request_body_reader.hpp
+++ b/gems/vajra/ext/vajra/request/request_body_reader.hpp
@@ -9,6 +9,7 @@
 #include "request_head_types.hpp"
 
 #include <cstddef>
+#include <stdexcept>
 #include <string>
 
 namespace Vajra
@@ -23,6 +24,14 @@ namespace Vajra
     {
       std::string body;
       std::string remaining_buffered_bytes;
+    };
+
+    class BodyReadIncompleteError : public std::runtime_error
+    {
+    public:
+      BodyReadIncompleteError() : std::runtime_error("request body read incomplete")
+      {
+      }
     };
 
     class RequestBodyReader

--- a/gems/vajra/ext/vajra/request/request_body_reader.hpp
+++ b/gems/vajra/ext/vajra/request/request_body_reader.hpp
@@ -1,0 +1,34 @@
+// Copyright Codevedas Inc. 2025-present
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef VAJRA_REQUEST_BODY_READER_HPP
+#define VAJRA_REQUEST_BODY_READER_HPP
+
+#include "request_head_types.hpp"
+
+#include <string>
+
+namespace Vajra
+{
+  namespace request
+  {
+    struct BodyReadResult
+    {
+      std::string body;
+      std::string remaining_buffered_bytes;
+    };
+
+    class RequestBodyReader
+    {
+    public:
+      BodyReadResult read(
+          int client_fd,
+          const ParsedRequest &request,
+          std::string buffered_bytes = "") const;
+    };
+  }
+}
+
+#endif

--- a/gems/vajra/ext/vajra/request/request_context.hpp
+++ b/gems/vajra/ext/vajra/request/request_context.hpp
@@ -27,6 +27,7 @@ namespace Vajra
     {
       ParsedRequest request;
       SocketContext socket;
+      std::string request_body = "";
     };
   }
 }

--- a/gems/vajra/ext/vajra/request/request_processor.cpp
+++ b/gems/vajra/ext/vajra/request/request_processor.cpp
@@ -144,6 +144,10 @@ void Vajra::request::RequestProcessor::handle(int client_fd, const SocketContext
       request_context.request_body = std::move(body_read_result.body);
       buffered_bytes = std::move(body_read_result.remaining_buffered_bytes);
     }
+    catch (const BodyReadIncompleteError &)
+    {
+      return;
+    }
     catch (const HeadError &error)
     {
       reject_request_head(client_fd, error);

--- a/gems/vajra/ext/vajra/request/request_processor.cpp
+++ b/gems/vajra/ext/vajra/request/request_processor.cpp
@@ -128,7 +128,21 @@ void Vajra::request::RequestProcessor::handle(int client_fd, const SocketContext
     {
       request_context = RequestContext{
           request_head_parser_.parse(read_result.request_head),
-          socket_context};
+          socket_context,
+          ""};
+    }
+    catch (const HeadError &error)
+    {
+      reject_request_head(client_fd, error);
+      return;
+    }
+
+    try
+    {
+      BodyReadResult body_read_result =
+          request_body_reader_.read(client_fd, request_context.request, std::move(buffered_bytes));
+      request_context.request_body = std::move(body_read_result.body);
+      buffered_bytes = std::move(body_read_result.remaining_buffered_bytes);
     }
     catch (const HeadError &error)
     {

--- a/gems/vajra/ext/vajra/request/request_processor.hpp
+++ b/gems/vajra/ext/vajra/request/request_processor.hpp
@@ -7,6 +7,7 @@
 #define VAJRA_REQUEST_PROCESSOR_HPP
 
 #include "request_context.hpp"
+#include "request_body_reader.hpp"
 #include "request_executor.hpp"
 #include "request_head_parser.hpp"
 #include "request_head_reader.hpp"
@@ -39,6 +40,7 @@ namespace Vajra
 
       HeadReader request_head_reader_;
       RequestHeadParser request_head_parser_;
+      RequestBodyReader request_body_reader_;
       Vajra::response::ResponseWriter response_writer_;
       std::shared_ptr<const RequestExecutor> request_executor_;
     };

--- a/gems/vajra/lib/vajra/internal/rack_execution.rb
+++ b/gems/vajra/lib/vajra/internal/rack_execution.rb
@@ -81,9 +81,12 @@ module Vajra
       private_class_method :build_env
 
       def binary_request_body(request_body)
-        body = String(request_body)
-        body = body.dup if body.frozen?
-        body.force_encoding(Encoding::BINARY) unless body.encoding == Encoding::BINARY
+        raise TypeError, 'request_body must be a String' unless request_body.is_a?(String)
+
+        body = request_body
+        body_encoding = body.encoding
+        body = body.dup if body.frozen? || body_encoding != Encoding::BINARY
+        body.force_encoding(Encoding::BINARY) unless body_encoding == Encoding::BINARY
         body
       end
       private_class_method :binary_request_body

--- a/gems/vajra/lib/vajra/internal/rack_execution.rb
+++ b/gems/vajra/lib/vajra/internal/rack_execution.rb
@@ -71,7 +71,7 @@ module Vajra
         env['QUERY_STRING'] ||= ''
         env['rack.version'] = RACK_VERSION
         env['rack.url_scheme'] ||= 'http'
-        env['rack.input'] = StringIO.new(String(request_body).b)
+        env['rack.input'] = StringIO.new(binary_request_body(request_body))
         env['rack.errors'] = $stderr
         env['rack.multithread'] = false
         env['rack.multiprocess'] = false
@@ -79,6 +79,14 @@ module Vajra
         env
       end
       private_class_method :build_env
+
+      def binary_request_body(request_body)
+        body = String(request_body)
+        body = body.dup if body.frozen?
+        body.force_encoding(Encoding::BINARY) unless body.encoding == Encoding::BINARY
+        body
+      end
+      private_class_method :binary_request_body
 
       def normalize_headers(headers)
         normalized_headers = []

--- a/gems/vajra/lib/vajra/internal/rack_execution.rb
+++ b/gems/vajra/lib/vajra/internal/rack_execution.rb
@@ -25,7 +25,7 @@ module Vajra
         app.method(:call)
 
         APP_MUTEX.synchronize { APP_STATE.app = app }
-        __native_set_callback__(proc { |env_entries| Vajra::Internal::RackExecution.call(env_entries) })
+        __native_set_callback__(proc { |env_entries, request_body| Vajra::Internal::RackExecution.call(env_entries, request_body) })
         app
       rescue NameError
         raise TypeError, 'Rack app must respond to #call'
@@ -40,13 +40,13 @@ module Vajra
         !current_app.equal?(nil)
       end
 
-      def call(env_entries)
+      def call(env_entries, request_body)
         body = UNSET_BODY
         body_close_managed = false
         app = current_app
         return nil if app.equal?(nil)
 
-        env = build_env(env_entries)
+        env = build_env(env_entries, request_body)
         status, headers, body = app.call(env)
         normalized_response = [
           Integer(status),
@@ -61,7 +61,7 @@ module Vajra
         close_body(body) if !body_close_managed && !body.equal?(UNSET_BODY)
       end
 
-      def build_env(env_entries)
+      def build_env(env_entries, request_body)
         env = {}
         env_entries.each do |key, value|
           env[key] = value
@@ -71,7 +71,7 @@ module Vajra
         env['QUERY_STRING'] ||= ''
         env['rack.version'] = RACK_VERSION
         env['rack.url_scheme'] ||= 'http'
-        env['rack.input'] = StringIO.new(''.b)
+        env['rack.input'] = StringIO.new(String(request_body).b)
         env['rack.errors'] = $stderr
         env['rack.multithread'] = false
         env['rack.multiprocess'] = false

--- a/gems/vajra/sig/vajra/internal/rack_execution.rbs
+++ b/gems/vajra/sig/vajra/internal/rack_execution.rbs
@@ -27,7 +27,7 @@ module Vajra
       def self.install!: (_RackApp) -> _RackApp
       def self.uninstall!: () -> nil
       def self.installed?: () -> bool
-      def self.call: (Array[[String, String]]) -> [Integer, Array[[String, String]], String]?
+      def self.call: (Array[[String, String]], String) -> [Integer, Array[[String, String]], String]?
       def self.__native_set_callback__: (Proc | nil) -> (Proc | nil)
     end
   end

--- a/gems/vajra/spec/cpp/CMakeLists.txt
+++ b/gems/vajra/spec/cpp/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(vajra_server_test
   ../../ext/vajra/lifecycle/lifecycle_controller.cpp
   ../../ext/vajra/ipc/frame_header.cpp
   ../../ext/vajra/listener/listener_socket.cpp
+  ../../ext/vajra/request/request_body_reader.cpp
   ../../ext/vajra/request/request_head_reader.cpp
   ../../ext/vajra/request/request_processor.cpp
   ../../ext/vajra/request/rack_env.cpp

--- a/gems/vajra/spec/cpp/response_test.cpp
+++ b/gems/vajra/spec/cpp/response_test.cpp
@@ -856,7 +856,7 @@ namespace VajraSpecCpp
       fail("overlong chunk metadata was accepted");
     }
 
-    void test_request_body_reader_rejects_chunk_metadata_at_limit_without_crlf()
+    void test_request_body_reader_treats_chunk_metadata_at_limit_without_crlf_as_incomplete()
     {
       const Vajra::request::RequestBodyReader reader(
           Vajra::request::kDefaultMaxRequestBodyBytes,
@@ -870,18 +870,12 @@ namespace VajraSpecCpp
       {
         (void)reader.read(-1, request, "1234");
       }
-      catch (const Vajra::request::HeadError &error)
+      catch (const Vajra::request::BodyReadIncompleteError &)
       {
-        if (error.kind() != Vajra::request::HeadFailureKind::bad_request ||
-            std::string(error.what()).find("request body metadata exceeds maximum size") == std::string::npos)
-        {
-          fail("chunk metadata at the limit raised the wrong error");
-        }
-
         return;
       }
 
-      fail("chunk metadata at the limit was accepted without a terminating CRLF");
+      fail("chunk metadata at the limit was not treated as an incomplete read");
     }
 
     void test_request_body_reader_treats_transport_failures_as_incomplete_reads()
@@ -1521,7 +1515,7 @@ namespace VajraSpecCpp
     test_request_body_reader_preserves_buffered_suffix_after_chunked_body();
     test_request_body_reader_rejects_oversized_content_length_body();
     test_request_body_reader_rejects_overlong_chunk_metadata();
-    test_request_body_reader_rejects_chunk_metadata_at_limit_without_crlf();
+    test_request_body_reader_treats_chunk_metadata_at_limit_without_crlf_as_incomplete();
     test_request_body_reader_treats_transport_failures_as_incomplete_reads();
     test_request_processor_reads_fragmented_fixed_length_request_body();
     test_request_processor_decodes_chunked_request_body();

--- a/gems/vajra/spec/cpp/response_test.cpp
+++ b/gems/vajra/spec/cpp/response_test.cpp
@@ -1192,6 +1192,67 @@ namespace VajraSpecCpp
       }
     }
 
+    void test_request_processor_closes_quietly_when_request_body_is_incomplete()
+    {
+      int sockets[2];
+      if (socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) < 0)
+      {
+        fail("socketpair failed while setting up incomplete request body test");
+      }
+
+      FileDescriptorGuard client_socket(sockets[0]);
+      FileDescriptorGuard server_socket(sockets[1]);
+      suppress_sigpipe(client_socket.get());
+
+      const auto request_executor = std::make_shared<EchoRequestBodyExecutor>();
+      const Vajra::request::RequestProcessor processor(
+          Vajra::request::kDefaultMaxRequestHeadBytes,
+          request_executor);
+      std::thread processor_thread = start_request_processor_thread(processor, server_socket);
+
+      try
+      {
+        if (!send_all(
+                client_socket.get(),
+                "POST /partial HTTP/1.1\r\n"
+                "Host: example.test\r\n"
+                "Content-Length: 8\r\n"
+                "\r\n"
+                "body"))
+        {
+          fail("failed to send partial request body");
+        }
+
+        if (shutdown(client_socket.get(), SHUT_WR) < 0)
+        {
+          fail("failed to half-close partial request body socket");
+        }
+
+        if (!peer_closed_within(client_socket.get(), 500))
+        {
+          fail("request processor did not close after an incomplete request body");
+        }
+
+        const std::string response = read_all(client_socket.get());
+        if (!response.empty())
+        {
+          fail("incomplete request body unexpectedly produced a response");
+        }
+
+        client_socket.close_if_open();
+        processor_thread.join();
+      }
+      catch (...)
+      {
+        client_socket.close_if_open();
+        if (processor_thread.joinable())
+        {
+          processor_thread.join();
+        }
+        throw;
+      }
+    }
+
     void test_request_processor_returns_internal_server_error_when_executor_raises()
     {
       int sockets[2];
@@ -1444,6 +1505,7 @@ namespace VajraSpecCpp
     test_request_processor_rejects_conflicting_request_body_framing();
     test_request_processor_rejects_malformed_chunked_request_body();
     test_request_processor_rejects_oversized_request_body();
+    test_request_processor_closes_quietly_when_request_body_is_incomplete();
     test_request_processor_returns_internal_server_error_when_executor_raises();
     test_request_processor_returns_bad_request_when_executor_raises_head_error();
     test_request_processor_returns_internal_server_error_when_executor_response_is_invalid();

--- a/gems/vajra/spec/cpp/response_test.cpp
+++ b/gems/vajra/spec/cpp/response_test.cpp
@@ -728,7 +728,7 @@ namespace VajraSpecCpp
           fail("request with body framing did not receive the success response");
         }
 
-        if (response.substr(response.size() - 4) != "body")
+        if (response.size() < 4 || response.compare(response.size() - 4, 4, "body") != 0)
         {
           fail("request processor did not transport the fixed-length request body");
         }

--- a/gems/vajra/spec/cpp/response_test.cpp
+++ b/gems/vajra/spec/cpp/response_test.cpp
@@ -68,6 +68,19 @@ namespace VajraSpecCpp
       }
     };
 
+    class EchoRequestBodyExecutor final : public Vajra::request::RequestExecutor
+    {
+    public:
+      std::optional<Vajra::response::Response> execute(const Vajra::request::RequestContext &request_context) const override
+      {
+        return Vajra::response::Response{
+            Vajra::response::Status{200, "OK"},
+            {Vajra::response::Header{"Content-Type", "application/octet-stream"}},
+            request_context.request_body,
+            Vajra::response::ConnectionBehavior::close};
+      }
+    };
+
     std::thread start_request_processor_thread(
         const Vajra::request::RequestProcessor &processor,
         FileDescriptorGuard &server_socket)
@@ -689,7 +702,10 @@ namespace VajraSpecCpp
       FileDescriptorGuard server_socket(sockets[1]);
       suppress_sigpipe(client_socket.get());
 
-      const Vajra::request::RequestProcessor processor(Vajra::request::kDefaultMaxRequestHeadBytes);
+      const auto request_executor = std::make_shared<EchoRequestBodyExecutor>();
+      const Vajra::request::RequestProcessor processor(
+          Vajra::request::kDefaultMaxRequestHeadBytes,
+          request_executor);
       std::thread processor_thread = start_request_processor_thread(processor, server_socket);
 
       try
@@ -711,14 +727,280 @@ namespace VajraSpecCpp
           fail("request with body framing did not receive the success response");
         }
 
+        if (response.substr(response.size() - 4) != "body")
+        {
+          fail("request processor did not transport the fixed-length request body");
+        }
+
         if (response.find("Connection: close\r\n") == std::string::npos)
         {
-          fail("request with unread body framing did not force connection close");
+          fail("request with body framing did not force connection close");
         }
 
         if (!peer_closed_within(client_socket.get(), 500))
         {
-          fail("request processor left the connection open after unread body framing");
+          fail("request processor left the connection open after request body framing");
+        }
+
+        client_socket.close_if_open();
+        processor_thread.join();
+      }
+      catch (...)
+      {
+        client_socket.close_if_open();
+        if (processor_thread.joinable())
+        {
+          processor_thread.join();
+        }
+        throw;
+      }
+    }
+
+    void test_request_processor_reads_fragmented_fixed_length_request_body()
+    {
+      int sockets[2];
+      if (socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) < 0)
+      {
+        fail("socketpair failed while setting up fragmented fixed-length body test");
+      }
+
+      FileDescriptorGuard client_socket(sockets[0]);
+      FileDescriptorGuard server_socket(sockets[1]);
+      suppress_sigpipe(client_socket.get());
+
+      const auto request_executor = std::make_shared<EchoRequestBodyExecutor>();
+      const Vajra::request::RequestProcessor processor(
+          Vajra::request::kDefaultMaxRequestHeadBytes,
+          request_executor);
+      std::thread processor_thread = start_request_processor_thread(processor, server_socket);
+
+      try
+      {
+        if (!send_all(
+                client_socket.get(),
+                "POST /fragmented HTTP/1.1\r\n"
+                "Host: example.test\r\n"
+                "Content-Length: 11\r\n"
+                "\r\n"
+                "hello"))
+        {
+          fail("failed to send fixed-length body prefix");
+        }
+
+        if (!send_all(client_socket.get(), " world"))
+        {
+          fail("failed to send fixed-length body suffix");
+        }
+
+        const std::string response = read_http_response(client_socket.get());
+        if (response.substr(response.size() - 11) != "hello world")
+        {
+          fail("fragmented fixed-length request body was not reassembled");
+        }
+
+        client_socket.close_if_open();
+        processor_thread.join();
+      }
+      catch (...)
+      {
+        client_socket.close_if_open();
+        if (processor_thread.joinable())
+        {
+          processor_thread.join();
+        }
+        throw;
+      }
+    }
+
+    void test_request_processor_decodes_chunked_request_body()
+    {
+      int sockets[2];
+      if (socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) < 0)
+      {
+        fail("socketpair failed while setting up chunked body test");
+      }
+
+      FileDescriptorGuard client_socket(sockets[0]);
+      FileDescriptorGuard server_socket(sockets[1]);
+      suppress_sigpipe(client_socket.get());
+
+      const auto request_executor = std::make_shared<EchoRequestBodyExecutor>();
+      const Vajra::request::RequestProcessor processor(
+          Vajra::request::kDefaultMaxRequestHeadBytes,
+          request_executor);
+      std::thread processor_thread = start_request_processor_thread(processor, server_socket);
+
+      try
+      {
+        if (!send_all(
+                client_socket.get(),
+                "POST /chunked HTTP/1.1\r\n"
+                "Host: example.test\r\n"
+                "Transfer-Encoding: chunked\r\n"
+                "\r\n"
+                "3\r\nabc\r\n"
+                "6\r\n123456\r\n"
+                "0\r\n\r\n"))
+        {
+          fail("failed to send chunked request body");
+        }
+
+        const std::string response = read_http_response(client_socket.get());
+        if (response.substr(response.size() - 9) != "abc123456")
+        {
+          fail("chunked request body was not decoded correctly");
+        }
+
+        client_socket.close_if_open();
+        processor_thread.join();
+      }
+      catch (...)
+      {
+        client_socket.close_if_open();
+        if (processor_thread.joinable())
+        {
+          processor_thread.join();
+        }
+        throw;
+      }
+    }
+
+    void test_request_processor_decodes_chunked_request_body_with_extensions_and_trailers()
+    {
+      int sockets[2];
+      if (socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) < 0)
+      {
+        fail("socketpair failed while setting up chunked extension test");
+      }
+
+      FileDescriptorGuard client_socket(sockets[0]);
+      FileDescriptorGuard server_socket(sockets[1]);
+      suppress_sigpipe(client_socket.get());
+
+      const auto request_executor = std::make_shared<EchoRequestBodyExecutor>();
+      const Vajra::request::RequestProcessor processor(
+          Vajra::request::kDefaultMaxRequestHeadBytes,
+          request_executor);
+      std::thread processor_thread = start_request_processor_thread(processor, server_socket);
+
+      try
+      {
+        if (!send_all(
+                client_socket.get(),
+                "POST /chunked-extensions HTTP/1.1\r\n"
+                "Host: example.test\r\n"
+                "Transfer-Encoding: chunked\r\n"
+                "\r\n"
+                "5;foo=bar\r\nhello\r\n"
+                "1\r\n \r\n"
+                "0\r\n"
+                "X-Trailer: kept-native-only\r\n"
+                "\r\n"))
+        {
+          fail("failed to send chunked request with extensions and trailers");
+        }
+
+        const std::string response = read_http_response(client_socket.get());
+        if (response.substr(response.size() - 6) != "hello ")
+        {
+          fail("chunked body extensions or trailers were not handled correctly");
+        }
+
+        client_socket.close_if_open();
+        processor_thread.join();
+      }
+      catch (...)
+      {
+        client_socket.close_if_open();
+        if (processor_thread.joinable())
+        {
+          processor_thread.join();
+        }
+        throw;
+      }
+    }
+
+    void test_request_processor_rejects_conflicting_request_body_framing()
+    {
+      int sockets[2];
+      if (socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) < 0)
+      {
+        fail("socketpair failed while setting up conflicting request body framing test");
+      }
+
+      FileDescriptorGuard client_socket(sockets[0]);
+      FileDescriptorGuard server_socket(sockets[1]);
+      suppress_sigpipe(client_socket.get());
+
+      const Vajra::request::RequestProcessor processor(Vajra::request::kDefaultMaxRequestHeadBytes);
+      std::thread processor_thread = start_request_processor_thread(processor, server_socket);
+
+      try
+      {
+        if (!send_all(
+                client_socket.get(),
+                "POST /conflict HTTP/1.1\r\n"
+                "Host: example.test\r\n"
+                "Content-Length: 3\r\n"
+                "Transfer-Encoding: chunked\r\n"
+                "\r\n"
+                "3\r\nabc\r\n0\r\n\r\n"))
+        {
+          fail("failed to send conflicting request body framing");
+        }
+
+        const std::string response = read_http_response(client_socket.get());
+        if (response.find("HTTP/1.1 400 Bad Request\r\n") != 0)
+        {
+          fail("conflicting request body framing did not receive a 400 response");
+        }
+
+        client_socket.close_if_open();
+        processor_thread.join();
+      }
+      catch (...)
+      {
+        client_socket.close_if_open();
+        if (processor_thread.joinable())
+        {
+          processor_thread.join();
+        }
+        throw;
+      }
+    }
+
+    void test_request_processor_rejects_malformed_chunked_request_body()
+    {
+      int sockets[2];
+      if (socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) < 0)
+      {
+        fail("socketpair failed while setting up malformed chunked body test");
+      }
+
+      FileDescriptorGuard client_socket(sockets[0]);
+      FileDescriptorGuard server_socket(sockets[1]);
+      suppress_sigpipe(client_socket.get());
+
+      const Vajra::request::RequestProcessor processor(Vajra::request::kDefaultMaxRequestHeadBytes);
+      std::thread processor_thread = start_request_processor_thread(processor, server_socket);
+
+      try
+      {
+        if (!send_all(
+                client_socket.get(),
+                "POST /malformed-chunked HTTP/1.1\r\n"
+                "Host: example.test\r\n"
+                "Transfer-Encoding: chunked\r\n"
+                "\r\n"
+                "Z\r\nabc\r\n0\r\n\r\n"))
+        {
+          fail("failed to send malformed chunked request body");
+        }
+
+        const std::string response = read_http_response(client_socket.get());
+        if (response.find("HTTP/1.1 400 Bad Request\r\n") != 0)
+        {
+          fail("malformed chunked request body did not receive a 400 response");
         }
 
         client_socket.close_if_open();
@@ -976,6 +1258,11 @@ namespace VajraSpecCpp
     test_request_processor_handles_pipelined_read_ahead_without_losing_the_next_request();
     test_request_processor_closes_after_parse_error_response();
     test_request_processor_closes_after_request_body_framing();
+    test_request_processor_reads_fragmented_fixed_length_request_body();
+    test_request_processor_decodes_chunked_request_body();
+    test_request_processor_decodes_chunked_request_body_with_extensions_and_trailers();
+    test_request_processor_rejects_conflicting_request_body_framing();
+    test_request_processor_rejects_malformed_chunked_request_body();
     test_request_processor_returns_internal_server_error_when_executor_raises();
     test_request_processor_returns_bad_request_when_executor_raises_head_error();
     test_request_processor_returns_internal_server_error_when_executor_response_is_invalid();

--- a/gems/vajra/spec/cpp/response_test.cpp
+++ b/gems/vajra/spec/cpp/response_test.cpp
@@ -4,6 +4,7 @@
 // LICENSE file in the root directory of this source tree.
 
 #include "request/request_head_size_validator.hpp"
+#include "request/request_body_reader.hpp"
 #include "request/request_processor.hpp"
 #include "response/response_serializer.hpp"
 #include "response/response_writer.hpp"
@@ -756,6 +757,105 @@ namespace VajraSpecCpp
       }
     }
 
+    void test_request_body_reader_preserves_buffered_suffix_after_fixed_length_body()
+    {
+      Vajra::request::RequestBodyReader reader;
+      const Vajra::request::ParsedRequest request{
+          Vajra::request::ParsedRequestLine{"POST", "/", "HTTP/1.1"},
+          {Vajra::request::ParsedHeader{"Content-Length", "4"}}};
+
+      const Vajra::request::BodyReadResult result = reader.read(
+          -1,
+          request,
+          "bodyGET /next HTTP/1.1\r\nHost: example.test\r\n\r\n");
+
+      if (result.body != "body")
+      {
+        fail("fixed-length body reader did not preserve the request body");
+      }
+
+      if (result.remaining_buffered_bytes != "GET /next HTTP/1.1\r\nHost: example.test\r\n\r\n")
+      {
+        fail("fixed-length body reader did not preserve unread buffered bytes");
+      }
+    }
+
+    void test_request_body_reader_preserves_buffered_suffix_after_chunked_body()
+    {
+      Vajra::request::RequestBodyReader reader;
+      const Vajra::request::ParsedRequest request{
+          Vajra::request::ParsedRequestLine{"POST", "/", "HTTP/1.1"},
+          {Vajra::request::ParsedHeader{"Transfer-Encoding", "chunked"}}};
+
+      const Vajra::request::BodyReadResult result = reader.read(
+          -1,
+          request,
+          "3\r\nabc\r\n0\r\nX-Trailer: done\r\n\r\nGET /next HTTP/1.1\r\nHost: example.test\r\n\r\n");
+
+      if (result.body != "abc")
+      {
+        fail("chunked body reader did not decode the request body");
+      }
+
+      if (result.remaining_buffered_bytes != "GET /next HTTP/1.1\r\nHost: example.test\r\n\r\n")
+      {
+        fail("chunked body reader did not preserve unread buffered bytes");
+      }
+    }
+
+    void test_request_body_reader_rejects_oversized_content_length_body()
+    {
+      const Vajra::request::RequestBodyReader reader(4);
+      const Vajra::request::ParsedRequest request{
+          Vajra::request::ParsedRequestLine{"POST", "/", "HTTP/1.1"},
+          {Vajra::request::ParsedHeader{"Content-Length", "5"}}};
+
+      try
+      {
+        (void)reader.read(-1, request, "");
+      }
+      catch (const Vajra::request::HeadError &error)
+      {
+        if (error.kind() != Vajra::request::HeadFailureKind::bad_request ||
+            std::string(error.what()).find("request body exceeds maximum size") == std::string::npos)
+        {
+          fail("oversized content-length body raised the wrong error");
+        }
+
+        return;
+      }
+
+      fail("oversized content-length body was accepted");
+    }
+
+    void test_request_body_reader_rejects_overlong_chunk_metadata()
+    {
+      const Vajra::request::RequestBodyReader reader(
+          Vajra::request::kDefaultMaxRequestBodyBytes,
+          4,
+          Vajra::request::kDefaultMaxTrailerLineBytes);
+      const Vajra::request::ParsedRequest request{
+          Vajra::request::ParsedRequestLine{"POST", "/", "HTTP/1.1"},
+          {Vajra::request::ParsedHeader{"Transfer-Encoding", "chunked"}}};
+
+      try
+      {
+        (void)reader.read(-1, request, "12345");
+      }
+      catch (const Vajra::request::HeadError &error)
+      {
+        if (error.kind() != Vajra::request::HeadFailureKind::bad_request ||
+            std::string(error.what()).find("request body metadata exceeds maximum size") == std::string::npos)
+        {
+          fail("overlong chunk metadata raised the wrong error");
+        }
+
+        return;
+      }
+
+      fail("overlong chunk metadata was accepted");
+    }
+
     void test_request_processor_reads_fragmented_fixed_length_request_body()
     {
       int sockets[2];
@@ -1017,6 +1117,53 @@ namespace VajraSpecCpp
       }
     }
 
+    void test_request_processor_rejects_oversized_request_body()
+    {
+      int sockets[2];
+      if (socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) < 0)
+      {
+        fail("socketpair failed while setting up oversized request body test");
+      }
+
+      FileDescriptorGuard client_socket(sockets[0]);
+      FileDescriptorGuard server_socket(sockets[1]);
+      suppress_sigpipe(client_socket.get());
+
+      const Vajra::request::RequestProcessor processor(Vajra::request::kDefaultMaxRequestHeadBytes);
+      std::thread processor_thread = start_request_processor_thread(processor, server_socket);
+
+      try
+      {
+        if (!send_all(
+                client_socket.get(),
+                "POST /too-large HTTP/1.1\r\n"
+                "Host: example.test\r\n"
+                "Content-Length: 16777217\r\n"
+                "\r\n"))
+        {
+          fail("failed to send oversized request body framing");
+        }
+
+        const std::string response = read_http_response(client_socket.get());
+        if (response.find("HTTP/1.1 400 Bad Request\r\n") != 0)
+        {
+          fail("oversized request body did not receive a 400 response");
+        }
+
+        client_socket.close_if_open();
+        processor_thread.join();
+      }
+      catch (...)
+      {
+        client_socket.close_if_open();
+        if (processor_thread.joinable())
+        {
+          processor_thread.join();
+        }
+        throw;
+      }
+    }
+
     void test_request_processor_returns_internal_server_error_when_executor_raises()
     {
       int sockets[2];
@@ -1258,11 +1405,16 @@ namespace VajraSpecCpp
     test_request_processor_handles_pipelined_read_ahead_without_losing_the_next_request();
     test_request_processor_closes_after_parse_error_response();
     test_request_processor_closes_after_request_body_framing();
+    test_request_body_reader_preserves_buffered_suffix_after_fixed_length_body();
+    test_request_body_reader_preserves_buffered_suffix_after_chunked_body();
+    test_request_body_reader_rejects_oversized_content_length_body();
+    test_request_body_reader_rejects_overlong_chunk_metadata();
     test_request_processor_reads_fragmented_fixed_length_request_body();
     test_request_processor_decodes_chunked_request_body();
     test_request_processor_decodes_chunked_request_body_with_extensions_and_trailers();
     test_request_processor_rejects_conflicting_request_body_framing();
     test_request_processor_rejects_malformed_chunked_request_body();
+    test_request_processor_rejects_oversized_request_body();
     test_request_processor_returns_internal_server_error_when_executor_raises();
     test_request_processor_returns_bad_request_when_executor_raises_head_error();
     test_request_processor_returns_internal_server_error_when_executor_response_is_invalid();

--- a/gems/vajra/spec/cpp/response_test.cpp
+++ b/gems/vajra/spec/cpp/response_test.cpp
@@ -884,6 +884,29 @@ namespace VajraSpecCpp
       fail("chunk metadata at the limit was accepted without a terminating CRLF");
     }
 
+    void test_request_body_reader_treats_transport_failures_as_incomplete_reads()
+    {
+      Vajra::request::RequestBodyReader reader;
+      const Vajra::request::ParsedRequest request{
+          Vajra::request::ParsedRequestLine{"POST", "/", "HTTP/1.1"},
+          {Vajra::request::ParsedHeader{"Content-Length", "4"}}};
+
+      try
+      {
+        (void)reader.read(-1, request, "");
+      }
+      catch (const Vajra::request::BodyReadIncompleteError &)
+      {
+        return;
+      }
+      catch (const Vajra::request::HeadError &)
+      {
+        fail("transport failure was misclassified as invalid request body framing");
+      }
+
+      fail("transport failure did not raise an incomplete body read");
+    }
+
     void test_request_processor_reads_fragmented_fixed_length_request_body()
     {
       int sockets[2];
@@ -1499,6 +1522,7 @@ namespace VajraSpecCpp
     test_request_body_reader_rejects_oversized_content_length_body();
     test_request_body_reader_rejects_overlong_chunk_metadata();
     test_request_body_reader_rejects_chunk_metadata_at_limit_without_crlf();
+    test_request_body_reader_treats_transport_failures_as_incomplete_reads();
     test_request_processor_reads_fragmented_fixed_length_request_body();
     test_request_processor_decodes_chunked_request_body();
     test_request_processor_decodes_chunked_request_body_with_extensions_and_trailers();

--- a/gems/vajra/spec/cpp/response_test.cpp
+++ b/gems/vajra/spec/cpp/response_test.cpp
@@ -856,6 +856,34 @@ namespace VajraSpecCpp
       fail("overlong chunk metadata was accepted");
     }
 
+    void test_request_body_reader_rejects_chunk_metadata_at_limit_without_crlf()
+    {
+      const Vajra::request::RequestBodyReader reader(
+          Vajra::request::kDefaultMaxRequestBodyBytes,
+          4,
+          Vajra::request::kDefaultMaxTrailerLineBytes);
+      const Vajra::request::ParsedRequest request{
+          Vajra::request::ParsedRequestLine{"POST", "/", "HTTP/1.1"},
+          {Vajra::request::ParsedHeader{"Transfer-Encoding", "chunked"}}};
+
+      try
+      {
+        (void)reader.read(-1, request, "1234");
+      }
+      catch (const Vajra::request::HeadError &error)
+      {
+        if (error.kind() != Vajra::request::HeadFailureKind::bad_request ||
+            std::string(error.what()).find("request body metadata exceeds maximum size") == std::string::npos)
+        {
+          fail("chunk metadata at the limit raised the wrong error");
+        }
+
+        return;
+      }
+
+      fail("chunk metadata at the limit was accepted without a terminating CRLF");
+    }
+
     void test_request_processor_reads_fragmented_fixed_length_request_body()
     {
       int sockets[2];
@@ -1409,6 +1437,7 @@ namespace VajraSpecCpp
     test_request_body_reader_preserves_buffered_suffix_after_chunked_body();
     test_request_body_reader_rejects_oversized_content_length_body();
     test_request_body_reader_rejects_overlong_chunk_metadata();
+    test_request_body_reader_rejects_chunk_metadata_at_limit_without_crlf();
     test_request_processor_reads_fragmented_fixed_length_request_body();
     test_request_processor_decodes_chunked_request_body();
     test_request_processor_decodes_chunked_request_body_with_extensions_and_trailers();

--- a/gems/vajra/spec/e2e/vajra/rack_env_integration_spec.rb
+++ b/gems/vajra/spec/e2e/vajra/rack_env_integration_spec.rb
@@ -266,7 +266,222 @@ RSpec.describe 'Vajra Rack environment integration', :e2e, :integration do # rub
     )
   end
 
-  it 'rejects non-zero content length until rack body transport exists' do
+  it 'exposes fixed-length request bodies through rack.input' do
+    script = <<~RUBY
+      require "json"
+      require "vajra"
+
+      Vajra::Internal::RackExecution.install!(
+        lambda do |rack_env|
+          input = rack_env.fetch("rack.input")
+          first = input.read(2)
+          remainder = input.read
+          input.rewind
+          [200, { "Content-Type" => "application/json" }, [JSON.generate({
+            "encoding" => input.external_encoding.name,
+            "first" => first,
+            "remainder" => remainder,
+            "full" => input.read
+          })]]
+        end
+      )
+
+      Vajra.start
+    RUBY
+
+    result = rack_app_request_result(
+      script:,
+      request:
+        "POST /projects HTTP/1.1\r\n" \
+        "Host: example.test\r\n" \
+        "Content-Length: 3\r\n" \
+        "Connection: close\r\n\r\n" \
+        'abc'
+    )
+
+    response = parse_http_response(result[:response])
+    snapshot = JSON.parse(response[:body])
+
+    expect(result[:exitstatus]).to eq(0)
+    expect(response[:status_line]).to eq('HTTP/1.1 200 OK')
+    expect(response[:headers]).to include('connection' => 'close')
+    expect(snapshot).to eq(
+      'encoding' => 'ASCII-8BIT',
+      'first' => 'ab',
+      'remainder' => 'c',
+      'full' => 'abc'
+    )
+  end
+
+  it 'supports large fragmented fixed-length request bodies' do
+    script = <<~RUBY
+      require "json"
+      require "vajra"
+
+      Vajra::Internal::RackExecution.install!(
+        lambda do |rack_env|
+          body = rack_env.fetch("rack.input").read
+          [200, { "Content-Type" => "application/json" }, [JSON.generate({
+            "bytesize" => body.bytesize,
+            "prefix" => body.byteslice(0, 4),
+            "suffix" => body.byteslice(-4, 4)
+          })]]
+        end
+      )
+
+      Vajra.start
+    RUBY
+
+    request_body = ('body' * 3_000).b
+    first_chunk = String.new(
+      "POST /projects HTTP/1.1\r\n" \
+      "Host: example.test\r\n" \
+      "Content-Length: #{request_body.bytesize}\r\n" \
+      "Connection: close\r\n\r\n",
+      encoding: Encoding::BINARY
+    )
+    first_chunk << request_body.byteslice(0, 3_000)
+    result = rack_app_request_chunks_result(
+      script:,
+      chunks: [
+        first_chunk,
+        request_body.byteslice(3_000, 4_000),
+        request_body.byteslice(7_000..)
+      ],
+      pause: 0.01
+    )
+
+    response = parse_http_response(result[:response])
+    snapshot = JSON.parse(response[:body])
+
+    expect(result[:exitstatus]).to eq(0)
+    expect(response[:status_line]).to eq('HTTP/1.1 200 OK')
+    expect(response[:headers]).to include('connection' => 'close')
+    expect(snapshot).to eq(
+      'bytesize' => request_body.bytesize,
+      'prefix' => 'body',
+      'suffix' => 'body'
+    )
+  end
+
+  it 'decodes chunked request bodies and consumes trailers without surfacing them' do
+    script = <<~RUBY
+      require "json"
+      require "vajra"
+
+      Vajra::Internal::RackExecution.install!(
+        lambda do |rack_env|
+          input = rack_env.fetch("rack.input")
+          [200, { "Content-Type" => "application/json" }, [JSON.generate({
+            "body" => input.read,
+            "trailer_present" => rack_env.key?("HTTP_X_TRAILER")
+          })]]
+        end
+      )
+
+      Vajra.start
+    RUBY
+
+    result = rack_app_request_result(
+      script:,
+      request:
+        "POST /chunked HTTP/1.1\r\n" \
+        "Host: example.test\r\n" \
+        "Transfer-Encoding: chunked\r\n" \
+        "Connection: close\r\n\r\n" \
+        "3;foo=bar\r\nabc\r\n" \
+        "3\r\n123\r\n" \
+        "0\r\n" \
+        "X-Trailer: hidden\r\n\r\n"
+    )
+
+    response = parse_http_response(result[:response])
+    snapshot = JSON.parse(response[:body])
+
+    expect(result[:exitstatus]).to eq(0)
+    expect(response[:status_line]).to eq('HTTP/1.1 200 OK')
+    expect(response[:headers]).to include('connection' => 'close')
+    expect(snapshot).to eq(
+      'body' => 'abc123',
+      'trailer_present' => false
+    )
+  end
+
+  it 'decodes fragmented chunked request bodies' do
+    script = <<~RUBY
+      require "json"
+      require "vajra"
+
+      Vajra::Internal::RackExecution.install!(
+        lambda do |rack_env|
+          input = rack_env.fetch("rack.input")
+          first = input.read(4)
+          [200, { "Content-Type" => "application/json" }, [JSON.generate({
+            "first" => first,
+            "rest" => input.read
+          })]]
+        end
+      )
+
+      Vajra.start
+    RUBY
+
+    result = rack_app_request_chunks_result(
+      script:,
+      chunks: [
+        "POST /chunked-fragmented HTTP/1.1\r\n" \
+        "Host: example.test\r\n" \
+        "Transfer-Encoding: chunked\r\n" \
+        "Connection: close\r\n\r\n" \
+        "4\r\nte",
+        "st\r\n5\r\n123",
+        "45\r\n0\r\n\r\n"
+      ],
+      pause: 0.01
+    )
+
+    response = parse_http_response(result[:response])
+    snapshot = JSON.parse(response[:body])
+
+    expect(result[:exitstatus]).to eq(0)
+    expect(response[:status_line]).to eq('HTTP/1.1 200 OK')
+    expect(snapshot).to eq(
+      'first' => 'test',
+      'rest' => '12345'
+    )
+  end
+
+  it 'rejects malformed chunked request bodies' do
+    script = <<~RUBY
+      require "vajra"
+
+      Vajra::Internal::RackExecution.install!(
+        lambda do |_rack_env|
+          [200, { "Content-Type" => "text/plain" }, ["unexpected"]]
+        end
+      )
+
+      Vajra.start
+    RUBY
+
+    result = rack_app_request_result(
+      script:,
+      request:
+        "POST /projects HTTP/1.1\r\n" \
+        "Host: example.test\r\n" \
+        "Transfer-Encoding: chunked\r\n" \
+        "Connection: close\r\n\r\n" \
+        "Z\r\nabc\r\n0\r\n\r\n"
+    )
+
+    response = parse_http_response(result[:response])
+
+    expect(result[:exitstatus]).to eq(0)
+    expect(response[:status_line]).to eq('HTTP/1.1 400 Bad Request')
+    expect(response[:headers]).to include('connection' => 'close')
+  end
+
+  it 'rejects ambiguous content length and transfer encoding framing' do
     script = <<~RUBY
       require "vajra"
 
@@ -285,35 +500,6 @@ RSpec.describe 'Vajra Rack environment integration', :e2e, :integration do # rub
         "POST /projects HTTP/1.1\r\n" \
         "Host: example.test\r\n" \
         "Content-Length: 3\r\n" \
-        "Connection: close\r\n\r\n" \
-        'abc'
-    )
-
-    response = parse_http_response(result[:response])
-
-    expect(result[:exitstatus]).to eq(0)
-    expect(response[:status_line]).to eq('HTTP/1.1 400 Bad Request')
-    expect(response[:headers]).to include('connection' => 'close')
-  end
-
-  it 'rejects transfer-encoded requests until rack body transport exists' do
-    script = <<~RUBY
-      require "vajra"
-
-      Vajra::Internal::RackExecution.install!(
-        lambda do |_rack_env|
-          [200, { "Content-Type" => "text/plain" }, ["unexpected"]]
-        end
-      )
-
-      Vajra.start
-    RUBY
-
-    result = rack_app_request_result(
-      script:,
-      request:
-        "POST /projects HTTP/1.1\r\n" \
-        "Host: example.test\r\n" \
         "Transfer-Encoding: chunked\r\n" \
         "Connection: close\r\n\r\n" \
         "3\r\nabc\r\n0\r\n\r\n"

--- a/gems/vajra/spec/e2e/vajra/support/http_helpers.rb
+++ b/gems/vajra/spec/e2e/vajra/support/http_helpers.rb
@@ -275,13 +275,16 @@ module VajraE2EHttpHelpers
       selected_port = wait_for_banner(output)
 
       socket = TCPSocket.new(VajraE2EHelpers::LISTENER_HOST, selected_port)
-      chunks.each do |chunk|
-        socket.write(chunk)
-        sleep pause if pause
+      begin
+        chunks.each do |chunk|
+          socket.write(chunk)
+          sleep pause if pause
+        end
+        socket.close_write
+        response = read_raw_http_response(socket, wait_thread:, output:, request_label: 'rack_app_request_chunks_result')
+      ensure
+        socket.close unless socket.closed?
       end
-      socket.close_write
-      response = read_raw_http_response(socket, wait_thread:, output:, request_label: 'rack_app_request_chunks_result')
-      socket.close
 
       status = stop_process(wait_thread)
 

--- a/gems/vajra/spec/e2e/vajra/support/http_helpers.rb
+++ b/gems/vajra/spec/e2e/vajra/support/http_helpers.rb
@@ -269,4 +269,25 @@ module VajraE2EHttpHelpers
       cleanup_process(wait_thread, output)
     end
   end
+
+  def rack_app_request_chunks_result(script:, chunks:, port: disposable_listener_port, env: {}, pause: nil)
+    Open3.popen2e(vajra_env(port:).merge(env), *inline_ruby_command(script), chdir: VajraE2EHelpers::PACKAGE_ROOT) do |_stdin, output, wait_thread|
+      selected_port = wait_for_banner(output)
+
+      socket = TCPSocket.new(VajraE2EHelpers::LISTENER_HOST, selected_port)
+      chunks.each do |chunk|
+        socket.write(chunk)
+        sleep pause if pause
+      end
+      socket.close_write
+      response = read_raw_http_response(socket, wait_thread:, output:, request_label: 'rack_app_request_chunks_result')
+      socket.close
+
+      status = stop_process(wait_thread)
+
+      { exitstatus: status.exitstatus, response:, output: output.read, port: selected_port }
+    ensure
+      cleanup_process(wait_thread, output)
+    end
+  end
 end

--- a/gems/vajra/spec/vajra/internal/rack_execution_spec.rb
+++ b/gems/vajra/spec/vajra/internal/rack_execution_spec.rb
@@ -137,6 +137,14 @@ RSpec.describe Vajra::Internal::RackExecution do
     expect(input.external_encoding).to eq(Encoding::BINARY)
     expect(input.string).not_to equal(request_body)
     expect(input.read).to eq(request_body.b)
+    expect(request_body.encoding).not_to eq(Encoding::BINARY)
+  end
+
+  it 'rejects non-string request bodies' do
+    described_class.install!(->(_env) { [204, {}, []] })
+
+    expect { described_class.call([%w[REQUEST_METHOD POST]], nil) }
+      .to raise_error(TypeError, 'request_body must be a String')
   end
 
   it 'does not swallow close errors from the response body' do

--- a/gems/vajra/spec/vajra/internal/rack_execution_spec.rb
+++ b/gems/vajra/spec/vajra/internal/rack_execution_spec.rb
@@ -70,7 +70,8 @@ RSpec.describe Vajra::Internal::RackExecution do
         ['PATH_INFO', '/projects'],
         ['QUERY_STRING', 'filter=active'],
         ['rack.url_scheme', 'http']
-      ]
+      ],
+      "abc\x00".b
     )
 
     expect(status).to eq(200)
@@ -89,18 +90,21 @@ RSpec.describe Vajra::Internal::RackExecution do
       'rack.run_once' => false
     )
     expect(captured_env.fetch('rack.input').external_encoding).to eq(Encoding::BINARY)
-    expect(captured_env.fetch('rack.input').read).to eq('')
+    expect(captured_env.fetch('rack.input').read(2)).to eq('ab')
+    expect(captured_env.fetch('rack.input').read).to eq("c\x00".b)
+    captured_env.fetch('rack.input').rewind
+    expect(captured_env.fetch('rack.input').read).to eq("abc\x00".b)
     expect(captured_env.fetch('rack.errors')).to equal($stderr)
   end
 
   it 'returns nil when no Rack app is installed' do
-    expect(described_class.call([%w[REQUEST_METHOD GET]])).to be_nil
+    expect(described_class.call([%w[REQUEST_METHOD GET]], ''.b)).to be_nil
   end
 
   it 'collects a body that does not implement close' do
     described_class.install!(->(_env) { [204, {}, []] })
 
-    status, headers, body = described_class.call([%w[REQUEST_METHOD HEAD]])
+    status, headers, body = described_class.call([%w[REQUEST_METHOD HEAD]], ''.b)
 
     expect(status).to eq(204)
     expect(headers).to eq([])
@@ -110,7 +114,7 @@ RSpec.describe Vajra::Internal::RackExecution do
   it 'preserves binary body bytes' do
     described_class.install!(->(_env) { [200, {}, ["\xFF\0\x80".b]] })
 
-    _status, _headers, body = described_class.call([%w[REQUEST_METHOD GET]])
+    _status, _headers, body = described_class.call([%w[REQUEST_METHOD GET]], ''.b)
 
     expect(body.encoding).to eq(Encoding::BINARY)
     expect(body.bytes).to eq([255, 0, 128])
@@ -129,7 +133,7 @@ RSpec.describe Vajra::Internal::RackExecution do
 
     described_class.install!(->(_env) { [200, {}, closing_body] })
 
-    expect { described_class.call([%w[REQUEST_METHOD GET]]) }.to raise_error(NoMethodError)
+    expect { described_class.call([%w[REQUEST_METHOD GET]], ''.b) }.to raise_error(NoMethodError)
   end
 
   it 'closes the response body when status normalization raises' do
@@ -149,7 +153,7 @@ RSpec.describe Vajra::Internal::RackExecution do
 
     described_class.install!(->(_env) { ['bad-status', {}, closing_body] })
 
-    expect { described_class.call([%w[REQUEST_METHOD GET]]) }.to raise_error(ArgumentError)
+    expect { described_class.call([%w[REQUEST_METHOD GET]], ''.b) }.to raise_error(ArgumentError)
     expect(closing_body.closed?).to be(true)
   end
 
@@ -172,7 +176,7 @@ RSpec.describe Vajra::Internal::RackExecution do
 
     described_class.install!(->(_env) { [200, {}, closing_body] })
 
-    expect { described_class.call([%w[REQUEST_METHOD GET]]) }.to raise_error(RuntimeError, 'body exploded')
+    expect { described_class.call([%w[REQUEST_METHOD GET]], ''.b) }.to raise_error(RuntimeError, 'body exploded')
     expect(closing_body.close_calls).to eq(1)
   end
 end

--- a/gems/vajra/spec/vajra/internal/rack_execution_spec.rb
+++ b/gems/vajra/spec/vajra/internal/rack_execution_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe Vajra::Internal::RackExecution do
 
   it 'builds the Rack env and normalizes the response body and headers' do
     captured_env = nil
+    request_body = "abc\x00".b
     headers = Class.new do
       def each
         yield :content_type, 'text/plain'
@@ -71,7 +72,7 @@ RSpec.describe Vajra::Internal::RackExecution do
         ['QUERY_STRING', 'filter=active'],
         ['rack.url_scheme', 'http']
       ],
-      "abc\x00".b
+      request_body
     )
 
     expect(status).to eq(200)
@@ -90,6 +91,7 @@ RSpec.describe Vajra::Internal::RackExecution do
       'rack.run_once' => false
     )
     expect(captured_env.fetch('rack.input').external_encoding).to eq(Encoding::BINARY)
+    expect(captured_env.fetch('rack.input').string).to equal(request_body)
     expect(captured_env.fetch('rack.input').read(2)).to eq('ab')
     expect(captured_env.fetch('rack.input').read).to eq("c\x00".b)
     captured_env.fetch('rack.input').rewind
@@ -118,6 +120,23 @@ RSpec.describe Vajra::Internal::RackExecution do
 
     expect(body.encoding).to eq(Encoding::BINARY)
     expect(body.bytes).to eq([255, 0, 128])
+  end
+
+  it 'coerces frozen non-binary request bodies into mutable binary rack.input strings' do
+    captured_env = nil
+    request_body = "snowman-\u2603"
+
+    described_class.install!(lambda { |env|
+      captured_env = env
+      [204, {}, []]
+    })
+
+    described_class.call([%w[REQUEST_METHOD POST]], request_body)
+
+    input = captured_env.fetch('rack.input')
+    expect(input.external_encoding).to eq(Encoding::BINARY)
+    expect(input.string).not_to equal(request_body)
+    expect(input.read).to eq(request_body.b)
   end
 
   it 'does not swallow close errors from the response body' do


### PR DESCRIPTION
- Introduced support for fixed-length and chunked request bodies in the Rack integration.
- Updated the Rack environment to expose `rack.input` as a buffered binary input object.
- Enhanced the request processor to read and handle request bodies, including fragmented and chunked bodies.
- Added a new `RequestBodyReader` class to manage reading request bodies based on framing.
- Updated tests to cover scenarios for fragmented fixed-length and chunked request bodies.
- Modified the Rack execution callback to accept and process the request body.

closes: #49
closes: #50
closes: #51
closes: #52