### PR TITLE
feat: enhance lifecycle management with boot readiness

### DIFF
--- a/gems/vajra/ext/vajra/lifecycle/lifecycle_controller.cpp
+++ b/gems/vajra/ext/vajra/lifecycle/lifecycle_controller.cpp
@@ -78,18 +78,26 @@ namespace Vajra
       Snapshot snapshot_value;
       {
         std::lock_guard<std::mutex> lock(mutex_);
-        if (boot_readiness_ == BootReadiness::ready || state_ == State::draining)
+        if (boot_readiness_ == BootReadiness::ready)
         {
           return;
         }
 
-        if (state_ != State::listening && state_ != State::serving)
+        const bool listener_bound = listener_owned_ && listener_fd_ >= 0;
+        if (state_ == State::draining && listener_bound)
+        {
+          boot_readiness_ = BootReadiness::ready;
+          snapshot_value = snapshot_unlocked();
+        }
+        else if (state_ == State::listening || state_ == State::serving)
+        {
+          boot_readiness_ = BootReadiness::ready;
+          snapshot_value = snapshot_unlocked();
+        }
+        else
         {
           throw std::logic_error("lifecycle can only enter boot-ready from listening or serving");
         }
-
-        boot_readiness_ = BootReadiness::ready;
-        snapshot_value = snapshot_unlocked();
       }
 
       notify(HookPoint::boot_complete, snapshot_value);

--- a/gems/vajra/ext/vajra/lifecycle/lifecycle_controller.cpp
+++ b/gems/vajra/ext/vajra/lifecycle/lifecycle_controller.cpp
@@ -96,7 +96,7 @@ namespace Vajra
         }
         else
         {
-          throw std::logic_error("lifecycle can only enter boot-ready from listening or serving");
+          throw std::logic_error("lifecycle can only enter boot-ready from listening, serving, or draining with a bound listener");
         }
       }
 

--- a/gems/vajra/ext/vajra/lifecycle/lifecycle_controller.cpp
+++ b/gems/vajra/ext/vajra/lifecycle/lifecycle_controller.cpp
@@ -14,6 +14,7 @@ namespace Vajra
   {
     Controller::Controller()
         : state_(State::stopped),
+          boot_readiness_(BootReadiness::pending),
           last_stop_reason_(StopReason::none),
           listener_owned_(false),
           pending_stop_before_start_(false),
@@ -38,6 +39,7 @@ namespace Vajra
       }
 
       state_ = State::booting;
+      boot_readiness_ = BootReadiness::pending;
       last_stop_reason_ = StopReason::none;
       listener_owned_ = false;
       pending_stop_before_start_ = false;
@@ -48,8 +50,6 @@ namespace Vajra
 
     bool Controller::mark_listening(int listener_fd, int port)
     {
-      Snapshot snapshot_value;
-      bool notify_observer = false;
       {
         std::lock_guard<std::mutex> lock(mutex_);
         if (state_ == State::draining)
@@ -69,15 +69,30 @@ namespace Vajra
         listener_owned_ = true;
         port_ = port;
         listener_fd_ = listener_fd;
-        snapshot_value = snapshot_unlocked();
-        notify_observer = true;
-      }
-
-      if (notify_observer)
-      {
-        notify(HookPoint::boot_complete, snapshot_value);
       }
       return true;
+    }
+
+    void Controller::mark_boot_ready()
+    {
+      Snapshot snapshot_value;
+      {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (boot_readiness_ == BootReadiness::ready || state_ == State::draining)
+        {
+          return;
+        }
+
+        if (state_ != State::listening && state_ != State::serving)
+        {
+          throw std::logic_error("lifecycle can only enter boot-ready from listening or serving");
+        }
+
+        boot_readiness_ = BootReadiness::ready;
+        snapshot_value = snapshot_unlocked();
+      }
+
+      notify(HookPoint::boot_complete, snapshot_value);
     }
 
     void Controller::mark_serving()
@@ -174,6 +189,7 @@ namespace Vajra
           }
 
           state_ = State::stopped;
+          boot_readiness_ = BootReadiness::pending;
           listener_owned_ = false;
           pending_stop_before_start_ = false;
           listener_fd_ = -1;
@@ -199,6 +215,7 @@ namespace Vajra
       {
         std::lock_guard<std::mutex> lock(mutex_);
         state_ = State::failed;
+        boot_readiness_ = BootReadiness::failed;
         last_stop_reason_ = reason;
         listener_owned_ = false;
         pending_stop_before_start_ = false;
@@ -219,6 +236,7 @@ namespace Vajra
     {
       return Snapshot{
           state_,
+          boot_readiness_,
           last_stop_reason_,
           listener_owned_,
           port_,

--- a/gems/vajra/ext/vajra/lifecycle/lifecycle_controller.hpp
+++ b/gems/vajra/ext/vajra/lifecycle/lifecycle_controller.hpp
@@ -33,6 +33,13 @@ namespace Vajra
       listener_failure,
     };
 
+    enum class BootReadiness
+    {
+      pending,
+      ready,
+      failed,
+    };
+
     enum class HookPoint
     {
       boot_complete,
@@ -45,6 +52,7 @@ namespace Vajra
     struct Snapshot
     {
       State state;
+      BootReadiness boot_readiness;
       StopReason last_stop_reason;
       bool listener_owned;
       int port;
@@ -60,6 +68,7 @@ namespace Vajra
 
       bool begin_startup();
       bool mark_listening(int listener_fd, int port);
+      void mark_boot_ready();
       void mark_serving();
       void request_stop(StopReason reason);
       void finish_stop();
@@ -74,6 +83,7 @@ namespace Vajra
 
       mutable std::mutex mutex_;
       State state_;
+      BootReadiness boot_readiness_;
       StopReason last_stop_reason_;
       bool listener_owned_;
       bool pending_stop_before_start_;

--- a/gems/vajra/ext/vajra/server.cpp
+++ b/gems/vajra/ext/vajra/server.cpp
@@ -266,8 +266,8 @@ void Vajra::Server::start()
     lifecycle_.finish_stop();
     return;
   }
-  log_listening_banner(port_);
   lifecycle_.mark_boot_ready();
+  log_listening_banner(port_);
 
   for (;;)
   {

--- a/gems/vajra/ext/vajra/server.cpp
+++ b/gems/vajra/ext/vajra/server.cpp
@@ -75,6 +75,21 @@ namespace
     throw std::logic_error("unknown lifecycle state");
   }
 
+  const char *boot_readiness_name(Vajra::lifecycle::BootReadiness readiness)
+  {
+    switch (readiness)
+    {
+      case Vajra::lifecycle::BootReadiness::pending:
+        return "pending";
+      case Vajra::lifecycle::BootReadiness::ready:
+        return "ready";
+      case Vajra::lifecycle::BootReadiness::failed:
+        return "failed";
+    }
+
+    throw std::logic_error("unknown lifecycle boot readiness");
+  }
+
   const char *stop_reason_name(Vajra::lifecycle::StopReason reason)
   {
     switch (reason)
@@ -111,36 +126,43 @@ namespace
     stream << "[Vajra][" << event_type << "] " << utc_timestamp() << ' ' << message << std::endl;
   }
 
-  std::string lifecycle_details(const Vajra::lifecycle::Snapshot &snapshot)
+  std::string lifecycle_details(const Vajra::lifecycle::Snapshot &snapshot, const std::string &runtime_role)
   {
     std::ostringstream message;
     message << "state=" << state_name(snapshot.state)
+            << " boot_status=" << boot_readiness_name(snapshot.boot_readiness)
             << " stop_reason=" << stop_reason_name(snapshot.last_stop_reason)
             << " port=" << snapshot.port
             << " listener_owned=" << (snapshot.listener_owned ? "true" : "false")
             << " listener_fd=" << snapshot.listener_fd
             << " mode=single_process"
+            << " runtime_role=" << runtime_role
             << " worker_processes=0";
     return message.str();
   }
 
-  void log_runtime_event(const char *event_name, const Vajra::lifecycle::Snapshot &snapshot, std::ostream &stream)
+  void log_runtime_event(
+      const char *event_name,
+      const Vajra::lifecycle::Snapshot &snapshot,
+      const std::string &runtime_role,
+      std::ostream &stream)
   {
     std::ostringstream message;
-    message << "event=" << event_name << ' ' << lifecycle_details(snapshot);
+    message << "event=" << event_name << ' ' << lifecycle_details(snapshot, runtime_role);
     log_message("lifecycle", message.str(), stream);
   }
 
-  void log_booting_event()
+  void log_booting_event(const std::string &runtime_role)
   {
     const Vajra::lifecycle::Snapshot snapshot{
         Vajra::lifecycle::State::booting,
+        Vajra::lifecycle::BootReadiness::pending,
         Vajra::lifecycle::StopReason::none,
         false,
         -1,
         -1,
     };
-    log_runtime_event("booting", snapshot, std::cout);
+    log_runtime_event("booting", snapshot, runtime_role, std::cout);
   }
 
   void log_listening_banner(int port)
@@ -161,30 +183,32 @@ namespace
 Vajra::Server::Server(
     int port,
     std::size_t max_request_head_bytes,
-    std::shared_ptr<const request::RequestExecutor> request_executor)
+    std::shared_ptr<const request::RequestExecutor> request_executor,
+    std::string runtime_role)
     : port_(port),
       server_fd_(-1),
       listener_socket_(),
       request_processor_(max_request_head_bytes, std::move(request_executor)),
-      lifecycle_()
+      lifecycle_(),
+      runtime_role_(std::move(runtime_role))
 {
-  set_lifecycle_observer([](lifecycle::HookPoint hook_point, const lifecycle::Snapshot &snapshot) {
+  set_lifecycle_observer([this](lifecycle::HookPoint hook_point, const lifecycle::Snapshot &snapshot) {
     switch (hook_point)
     {
       case lifecycle::HookPoint::boot_complete:
-        log_runtime_event("boot_complete", snapshot, std::cout);
+        log_runtime_event("boot_complete", snapshot, runtime_role_, std::cout);
         return;
       case lifecycle::HookPoint::serving_entered:
-        log_runtime_event("serving_entered", snapshot, std::cout);
+        log_runtime_event("serving_entered", snapshot, runtime_role_, std::cout);
         return;
       case lifecycle::HookPoint::drain_requested:
-        log_runtime_event("drain_requested", snapshot, std::cout);
+        log_runtime_event("drain_requested", snapshot, runtime_role_, std::cout);
         return;
       case lifecycle::HookPoint::stop_completed:
-        log_runtime_event("stop_completed", snapshot, std::cout);
+        log_runtime_event("stop_completed", snapshot, runtime_role_, std::cout);
         return;
       case lifecycle::HookPoint::failed_entered:
-        log_runtime_event("failed_entered", snapshot, std::cerr);
+        log_runtime_event("failed_entered", snapshot, runtime_role_, std::cerr);
         return;
     }
 
@@ -221,7 +245,7 @@ void Vajra::Server::start()
     return;
   }
 
-  log_booting_event();
+  log_booting_event(runtime_role_);
 
   listener::SocketBinding binding;
   try
@@ -243,6 +267,7 @@ void Vajra::Server::start()
     return;
   }
   log_listening_banner(port_);
+  lifecycle_.mark_boot_ready();
 
   for (;;)
   {

--- a/gems/vajra/ext/vajra/server.hpp
+++ b/gems/vajra/ext/vajra/server.hpp
@@ -10,6 +10,7 @@
 #include <functional>
 #include <atomic>
 #include <memory>
+#include <string>
 
 #include "lifecycle/lifecycle_controller.hpp"
 #include "listener/listener_socket.hpp"
@@ -24,7 +25,8 @@ namespace Vajra
     explicit Server(
         int port,
         std::size_t max_request_head_bytes = request::kDefaultMaxRequestHeadBytes,
-        std::shared_ptr<const request::RequestExecutor> request_executor = nullptr);
+        std::shared_ptr<const request::RequestExecutor> request_executor = nullptr,
+        std::string runtime_role = "single_process_bootstrap");
     ~Server();
 
     void start();
@@ -38,6 +40,7 @@ namespace Vajra
     listener::Socket listener_socket_;
     request::RequestProcessor request_processor_;
     lifecycle::Controller lifecycle_;
+    std::string runtime_role_;
 
     void close_listener_fd(bool interrupt_accept);
   };

--- a/gems/vajra/ext/vajra/vajra.cpp
+++ b/gems/vajra/ext/vajra/vajra.cpp
@@ -235,7 +235,9 @@ namespace
 
     if (NIL_P(callback))
     {
-      rb_raise(rb_eRuntimeError, "Ruby boot contract callback is not installed");
+      rb_raise(
+          rb_eRuntimeError,
+          "Ruby boot contract callback is not installed. Require \"vajra\" or call Vajra::Internal::Boot.install! before starting Vajra.");
     }
 
     VALUE boot_request = ruby_boot_request_from(*config);

--- a/gems/vajra/ext/vajra/vajra.cpp
+++ b/gems/vajra/ext/vajra/vajra.cpp
@@ -16,6 +16,7 @@
 #include <memory>
 #include <mutex>
 #include <limits>
+#include <optional>
 #include <stdexcept>
 #include <cstring>
 #include <string>
@@ -27,11 +28,42 @@ namespace
   std::unique_ptr<Vajra::Server> server_instance;
   ID id_port;
   ID id_max_request_head_bytes;
+  ID id_runtime_role;
+  std::mutex boot_callback_mutex;
+  VALUE boot_callback = Qnil;
 
   struct RuntimeConfig
   {
     int port;
     std::size_t max_request_head_bytes;
+  };
+
+  struct BootContractConfig
+  {
+    int port;
+    std::size_t max_request_head_bytes;
+    std::string runtime_role;
+  };
+
+  struct BootDiagnostic
+  {
+    std::string code;
+    std::string category;
+    std::string message;
+  };
+
+  enum class BootStatus
+  {
+    pending,
+    ready,
+    failed,
+  };
+
+  struct BootContractResult
+  {
+    BootStatus status;
+    std::string runtime_role;
+    std::optional<BootDiagnostic> diagnostic;
   };
 
   struct ProtectedIntegerConversion
@@ -168,6 +200,144 @@ namespace
     const VALUE hash = lookup[0];
     const VALUE key = lookup[1];
     return rb_hash_lookup(hash, key);
+  }
+
+  std::string ruby_string_value(VALUE value, const char *error_message)
+  {
+    if (RB_TYPE_P(value, T_STRING) == 0)
+    {
+      throw std::runtime_error(error_message);
+    }
+
+    return std::string(RSTRING_PTR(value), static_cast<std::size_t>(RSTRING_LEN(value)));
+  }
+
+  VALUE ruby_boot_request_from(const BootContractConfig &config)
+  {
+    VALUE boot_request = rb_hash_new();
+    rb_hash_aset(boot_request, ID2SYM(id_port), INT2NUM(config.port));
+    rb_hash_aset(boot_request, ID2SYM(id_max_request_head_bytes), SIZET2NUM(config.max_request_head_bytes));
+    rb_hash_aset(
+        boot_request,
+        ID2SYM(id_runtime_role),
+        rb_str_new(config.runtime_role.data(), static_cast<long>(config.runtime_role.size())));
+    return boot_request;
+  }
+
+  VALUE protected_execute_boot_callback(VALUE data)
+  {
+    auto *config = reinterpret_cast<BootContractConfig *>(data);
+    VALUE callback = Qnil;
+    {
+      const std::lock_guard<std::mutex> callback_lock(boot_callback_mutex);
+      callback = boot_callback;
+    }
+
+    if (NIL_P(callback))
+    {
+      rb_raise(rb_eRuntimeError, "Ruby boot contract callback is not installed");
+    }
+
+    VALUE boot_request = ruby_boot_request_from(*config);
+    VALUE arguments[] = {boot_request};
+    return rb_proc_call(callback, rb_ary_new_from_values(1, arguments));
+  }
+
+  BootStatus boot_status_from_ruby(VALUE status)
+  {
+    const std::string status_value = ruby_string_value(status, "Ruby boot contract returned a non-string status");
+    if (status_value == "pending")
+    {
+      return BootStatus::pending;
+    }
+    if (status_value == "ready")
+    {
+      return BootStatus::ready;
+    }
+    if (status_value == "failed")
+    {
+      return BootStatus::failed;
+    }
+
+    throw std::runtime_error("Ruby boot contract returned an unsupported status");
+  }
+
+  std::optional<BootDiagnostic> boot_diagnostic_from_ruby(VALUE diagnostic)
+  {
+    if (NIL_P(diagnostic))
+    {
+      return std::nullopt;
+    }
+
+    if (TYPE(diagnostic) != T_ARRAY || RARRAY_LEN(diagnostic) != 3)
+    {
+      throw std::runtime_error("Ruby boot contract returned an invalid diagnostic");
+    }
+
+    return BootDiagnostic{
+        ruby_string_value(rb_ary_entry(diagnostic, 0), "Ruby boot contract returned a non-string diagnostic code"),
+        ruby_string_value(rb_ary_entry(diagnostic, 1), "Ruby boot contract returned a non-string diagnostic category"),
+        ruby_string_value(rb_ary_entry(diagnostic, 2), "Ruby boot contract returned a non-string diagnostic message")};
+  }
+
+  BootContractResult boot_result_from_ruby(VALUE result)
+  {
+    if (TYPE(result) != T_ARRAY || RARRAY_LEN(result) != 3)
+    {
+      throw std::runtime_error("Ruby boot contract returned an invalid result");
+    }
+
+    return BootContractResult{
+        boot_status_from_ruby(rb_ary_entry(result, 0)),
+        ruby_string_value(rb_ary_entry(result, 1), "Ruby boot contract returned a non-string runtime role"),
+        boot_diagnostic_from_ruby(rb_ary_entry(result, 2))};
+  }
+
+  BootContractResult run_boot_contract(const BootContractConfig &config)
+  {
+    int state = 0;
+    VALUE result = rb_protect(
+        protected_execute_boot_callback,
+        reinterpret_cast<VALUE>(const_cast<BootContractConfig *>(&config)),
+        &state);
+    if (state == 0)
+    {
+      return boot_result_from_ruby(result);
+    }
+
+    VALUE message = Qnil;
+    int message_state = 0;
+    message = rb_protect(protected_format_ruby_exception_message, Qnil, &message_state);
+    rb_set_errinfo(Qnil);
+
+    if (message_state != 0 || NIL_P(message))
+    {
+      throw std::runtime_error("Ruby boot contract execution failed: Ruby exception");
+    }
+
+    throw std::runtime_error("Ruby boot contract execution failed: " + std::string(StringValueCStr(message)));
+  }
+
+  void ensure_ready_boot_result(const BootContractResult &result)
+  {
+    switch (result.status)
+    {
+      case BootStatus::ready:
+        return;
+      case BootStatus::pending:
+        throw std::runtime_error("Ruby boot contract did not reach ready state");
+      case BootStatus::failed:
+        if (!result.diagnostic.has_value())
+        {
+          throw std::runtime_error("Ruby boot failed without diagnostic details");
+        }
+
+        throw std::runtime_error(
+            "Ruby boot failed (" + result.diagnostic->code + "/" + result.diagnostic->category + "): " +
+            result.diagnostic->message);
+    }
+
+    throw std::runtime_error("Ruby boot contract returned an unknown state");
   }
 
   int validate_start_option_key(VALUE key, VALUE, VALUE data)
@@ -363,7 +533,10 @@ namespace
       VALUE options = Qnil;
       rb_scan_args(argc, argv, "0:", &options);
       const RuntimeConfig config = configured_runtime(options);
-      VajraNative::start(config.port, config.max_request_head_bytes);
+      const BootContractResult boot_result = run_boot_contract(
+          BootContractConfig{config.port, config.max_request_head_bytes, "single_process_bootstrap"});
+      ensure_ready_boot_result(boot_result);
+      VajraNative::start(config.port, config.max_request_head_bytes, boot_result.runtime_role);
     }
     catch (const std::exception &error)
     {
@@ -392,6 +565,16 @@ namespace
     Vajra::rack::set_rack_execution_callback(callback);
     return callback;
   }
+
+  VALUE rb_boot_native_set_callback(VALUE self, VALUE callback)
+  {
+    (void)self;
+    {
+      const std::lock_guard<std::mutex> callback_lock(boot_callback_mutex);
+      boot_callback = callback;
+    }
+    return callback;
+  }
 }
 
 namespace VajraNative
@@ -401,7 +584,7 @@ namespace VajraNative
     return shutting_down != 0;
   }
 
-  void start(int port, std::size_t max_request_head_bytes)
+  void start(int port, std::size_t max_request_head_bytes, const std::string &runtime_role)
   {
     SignalHandlerGuard signal_handler_guard;
     signal_handler_guard.install();
@@ -421,7 +604,8 @@ namespace VajraNative
         server_instance = std::make_unique<Vajra::Server>(
             port,
             max_request_head_bytes,
-            std::make_shared<Vajra::rack::RackRequestExecutor>());
+            std::make_shared<Vajra::rack::RackRequestExecutor>(),
+            runtime_role);
         server = server_instance.get();
       }
 
@@ -459,12 +643,20 @@ extern "C" void Init_vajra()
 {
   id_port = rb_intern("port");
   id_max_request_head_bytes = rb_intern("max_request_head_bytes");
+  id_runtime_role = rb_intern("runtime_role");
+  rb_global_variable(&boot_callback);
   Vajra::rack::initialize_rack_execution_bridge();
   VALUE mVajra = rb_define_module("Vajra");
   VALUE mInternal = rb_define_module_under(mVajra, "Internal");
+  VALUE mBoot = rb_define_module_under(mInternal, "Boot");
   VALUE mRackExecution = rb_define_module_under(mInternal, "RackExecution");
   rb_define_singleton_method(mVajra, "start", RUBY_METHOD_FUNC(rb_vajra_start), -1);
   rb_define_singleton_method(mVajra, "stop", RUBY_METHOD_FUNC(rb_vajra_stop), 0);
+  rb_define_singleton_method(
+      mBoot,
+      "__native_set_boot_callback__",
+      RUBY_METHOD_FUNC(rb_boot_native_set_callback),
+      1);
   rb_define_singleton_method(
       mRackExecution,
       "__native_set_callback__",

--- a/gems/vajra/ext/vajra/vajra.cpp
+++ b/gems/vajra/ext/vajra/vajra.cpp
@@ -261,7 +261,7 @@ namespace
       return BootStatus::failed;
     }
 
-    throw std::runtime_error("Ruby boot contract returned an unsupported status");
+    throw std::runtime_error("Ruby boot contract returned an unsupported status: " + status_value);
   }
 
   std::optional<BootDiagnostic> boot_diagnostic_from_ruby(VALUE diagnostic)

--- a/gems/vajra/ext/vajra/vajra.hpp
+++ b/gems/vajra/ext/vajra/vajra.hpp
@@ -9,10 +9,15 @@
 #include "server.hpp"
 #include "request/request_head_error.hpp"
 
+#include <string>
+
 namespace VajraNative
 {
   bool shutdown_requested();
-  void start(int port = 3000, std::size_t max_request_head_bytes = Vajra::request::kDefaultMaxRequestHeadBytes);
+  void start(
+      int port = 3000,
+      std::size_t max_request_head_bytes = Vajra::request::kDefaultMaxRequestHeadBytes,
+      const std::string &runtime_role = "single_process_bootstrap");
   void stop();
 }
 

--- a/gems/vajra/lib/vajra.rb
+++ b/gems/vajra/lib/vajra.rb
@@ -6,6 +6,7 @@
 # LICENSE file in the root directory of this source tree.
 
 require_relative 'vajra/version'
+require_relative 'vajra/internal/boot'
 require_relative 'vajra/internal/rack_execution'
 
 # Ruby entrypoint for booting the native Vajra HTTP listener.
@@ -29,6 +30,7 @@ module Vajra
   end
 
   NativeExtension.load!
+  Vajra::Internal::Boot.install!
 
   class << self
     def header

--- a/gems/vajra/lib/vajra/internal/boot.rb
+++ b/gems/vajra/lib/vajra/internal/boot.rb
@@ -1,0 +1,187 @@
+# frozen_string_literal: true
+
+# Copyright Codevedas Inc. 2025-present
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+module Vajra
+  module Internal
+    # Coordinates Ruby boot readiness for the native startup path.
+    module Boot
+      module_function
+
+      STATUSES = {
+        ready: 'ready',
+        failed: 'failed',
+        pending: 'pending'
+      }.freeze
+      SINGLE_PROCESS_BOOTSTRAP_ROLE = 'single_process_bootstrap'
+
+      # Raised when the Ruby/native boot callback contract is malformed.
+      class BootContractError < StandardError
+      end
+      # Stores the currently configured boot coordinator callback.
+      BootState = Struct.new(:coordinator)
+
+      BOOT_MUTEX = Mutex.new
+      BOOT_STATE = BootState.new(nil)
+
+      def install!(coordinator = method(:default_coordinator))
+        coordinator.method(:call)
+
+        BOOT_MUTEX.synchronize { BOOT_STATE.coordinator = coordinator }
+        __native_set_boot_callback__(bootstrap_callback)
+        coordinator
+      rescue NameError
+        raise TypeError, 'boot coordinator must respond to #call'
+      end
+
+      def uninstall!
+        BOOT_MUTEX.synchronize { BOOT_STATE.coordinator = nil }
+        __native_set_boot_callback__(nil)
+      end
+
+      def installed?
+        !configured_coordinator.equal?(nil)
+      end
+
+      def call(boot_request)
+        normalize_boot_result(active_coordinator.call(normalize_boot_request(boot_request)))
+      rescue StandardError => e
+        failure_result(
+          code: normalized_failure_code(e),
+          category: failure_category_for(e),
+          message: "#{e.class}: #{e.message}"
+        )
+      end
+
+      def default_coordinator(_boot_request)
+        {
+          status: STATUSES.fetch(:ready),
+          role: SINGLE_PROCESS_BOOTSTRAP_ROLE
+        }
+      end
+      private_class_method :default_coordinator
+
+      def bootstrap_callback
+        proc { |boot_request| Vajra::Internal::Boot.call(boot_request) }
+      end
+      private_class_method :bootstrap_callback
+
+      def configured_coordinator
+        BOOT_MUTEX.synchronize { BOOT_STATE.coordinator }
+      end
+      private_class_method :configured_coordinator
+
+      def active_coordinator
+        configured_coordinator || method(:default_coordinator)
+      end
+      private_class_method :active_coordinator
+
+      def normalize_boot_request(boot_request)
+        raise BootContractError, 'boot request must be a Hash' unless boot_request.is_a?(Hash)
+
+        request = boot_request.transform_keys(&:to_sym)
+        {
+          port: Integer(request.fetch(:port)),
+          max_request_head_bytes: Integer(request.fetch(:max_request_head_bytes)),
+          runtime_role: String(request.fetch(:runtime_role))
+        }
+      rescue KeyError => e
+        raise BootContractError, "missing boot request field: #{e.key}"
+      rescue ArgumentError, TypeError => e
+        raise BootContractError, e.message
+      end
+      private_class_method :normalize_boot_request
+
+      def normalize_boot_result(result)
+        status, role, diagnostic = unpack_result(result)
+        normalized_status = normalize_status(status)
+        normalized_role = String(role)
+        raise BootContractError, 'boot role must not be empty' if normalized_role.empty?
+
+        [normalized_status, normalized_role, normalize_diagnostic(diagnostic)]
+      end
+      private_class_method :normalize_boot_result
+
+      def unpack_result(result)
+        return [result.fetch(:status), result.fetch(:role), result[:diagnostic]] if result.is_a?(Hash)
+        return [result, SINGLE_PROCESS_BOOTSTRAP_ROLE, nil] if result.is_a?(String) || result.is_a?(Symbol)
+
+        return result if result.is_a?(Array) && result.length == 3
+
+        raise BootContractError, 'boot coordinator must return a boot result'
+      rescue KeyError => e
+        raise BootContractError, "missing boot result field: #{e.key}"
+      end
+      private_class_method :unpack_result
+
+      def normalize_status(status)
+        normalized_status = String(status)
+        return normalized_status if STATUSES.value?(normalized_status)
+
+        raise BootContractError, "unsupported boot status: #{normalized_status}"
+      end
+      private_class_method :normalize_status
+
+      def normalize_diagnostic(diagnostic)
+        diagnostic&.then { |value| stringify_diagnostic_values(diagnostic_values_from(value)) }
+      rescue KeyError => e
+        raise BootContractError, "missing boot diagnostic field: #{e.key}"
+      end
+      private_class_method :normalize_diagnostic
+
+      def diagnostic_values_from(diagnostic)
+        case diagnostic
+        when Hash
+          [
+            diagnostic.fetch(:code),
+            diagnostic.fetch(:category),
+            diagnostic.fetch(:message)
+          ]
+        when Array
+          invalid_boot_diagnostic! unless diagnostic.length == 3
+
+          diagnostic
+        else
+          invalid_boot_diagnostic!
+        end
+      end
+      private_class_method :diagnostic_values_from
+
+      def stringify_diagnostic_values(diagnostic_values)
+        diagnostic_values.map { |value| String(value) }
+      end
+      private_class_method :stringify_diagnostic_values
+
+      def invalid_boot_diagnostic!
+        raise BootContractError, 'boot diagnostic must be a Hash or 3-item Array'
+      end
+      private_class_method :invalid_boot_diagnostic!
+
+      def failure_result(code:, category:, message:)
+        [
+          STATUSES.fetch(:failed),
+          SINGLE_PROCESS_BOOTSTRAP_ROLE,
+          [String(code), String(category), String(message)]
+        ]
+      end
+      private_class_method :failure_result
+
+      def normalized_failure_code(error)
+        return 'invalid_boot_contract' if error.is_a?(BootContractError)
+
+        'boot_callback_error'
+      end
+      private_class_method :normalized_failure_code
+
+      def failure_category_for(error)
+        return 'contract' if error.is_a?(BootContractError)
+
+        'boot'
+      end
+      private_class_method :failure_category_for
+    end
+  end
+end

--- a/gems/vajra/lib/vajra/internal/boot.rb
+++ b/gems/vajra/lib/vajra/internal/boot.rb
@@ -28,13 +28,11 @@ module Vajra
       BOOT_STATE = BootState.new(nil)
 
       def install!(coordinator = method(:default_coordinator))
-        coordinator.method(:call)
+        validate_coordinator!(coordinator)
 
         BOOT_MUTEX.synchronize { BOOT_STATE.coordinator = coordinator }
         __native_set_boot_callback__(bootstrap_callback)
         coordinator
-      rescue NameError
-        raise TypeError, 'boot coordinator must respond to #call'
       end
 
       def uninstall!
@@ -68,6 +66,15 @@ module Vajra
         proc { |boot_request| Vajra::Internal::Boot.call(boot_request) }
       end
       private_class_method :bootstrap_callback
+
+      def validate_coordinator!(coordinator)
+        coordinator.method(:call)
+      rescue NameError => e
+        raise unless e.name == :call
+
+        raise TypeError, 'boot coordinator must respond to #call'
+      end
+      private_class_method :validate_coordinator!
 
       def configured_coordinator
         BOOT_MUTEX.synchronize { BOOT_STATE.coordinator }

--- a/gems/vajra/lib/vajra/internal/boot.rb
+++ b/gems/vajra/lib/vajra/internal/boot.rb
@@ -82,11 +82,10 @@ module Vajra
       def normalize_boot_request(boot_request)
         raise BootContractError, 'boot request must be a Hash' unless boot_request.is_a?(Hash)
 
-        request = boot_request.transform_keys(&:to_sym)
         {
-          port: Integer(request.fetch(:port)),
-          max_request_head_bytes: Integer(request.fetch(:max_request_head_bytes)),
-          runtime_role: String(request.fetch(:runtime_role))
+          port: Integer(fetch_boot_request_value(boot_request, :port)),
+          max_request_head_bytes: Integer(fetch_boot_request_value(boot_request, :max_request_head_bytes)),
+          runtime_role: String(fetch_boot_request_value(boot_request, :runtime_role))
         }
       rescue KeyError => e
         raise BootContractError, "missing boot request field: #{e.key}"
@@ -94,6 +93,13 @@ module Vajra
         raise BootContractError, e.message
       end
       private_class_method :normalize_boot_request
+
+      def fetch_boot_request_value(boot_request, key)
+        return boot_request.fetch(key) if boot_request.key?(key)
+
+        boot_request.fetch(String(key))
+      end
+      private_class_method :fetch_boot_request_value
 
       def normalize_boot_result(result)
         status, role, diagnostic = unpack_result(result)

--- a/gems/vajra/lib/vajra/internal/boot.rb
+++ b/gems/vajra/lib/vajra/internal/boot.rb
@@ -107,7 +107,12 @@ module Vajra
         normalized_role = String(role)
         raise BootContractError, 'boot role must not be empty' if normalized_role.empty?
 
-        [normalized_status, normalized_role, normalize_diagnostic(diagnostic)]
+        normalized_diagnostic = normalize_diagnostic(diagnostic)
+        if [normalized_status, normalized_diagnostic] == [STATUSES.fetch(:failed), nil]
+          raise BootContractError, 'failed boot results must include diagnostic details'
+        end
+
+        [normalized_status, normalized_role, normalized_diagnostic]
       end
       private_class_method :normalize_boot_result
 

--- a/gems/vajra/lib/vajra/internal/boot.rb
+++ b/gems/vajra/lib/vajra/internal/boot.rb
@@ -30,8 +30,8 @@ module Vajra
       def install!(coordinator = method(:default_coordinator))
         validate_coordinator!(coordinator)
 
-        BOOT_MUTEX.synchronize { BOOT_STATE.coordinator = coordinator }
         __native_set_boot_callback__(bootstrap_callback)
+        BOOT_MUTEX.synchronize { BOOT_STATE.coordinator = coordinator }
         coordinator
       end
 
@@ -92,7 +92,7 @@ module Vajra
         {
           port: Integer(fetch_boot_request_value(boot_request, :port)),
           max_request_head_bytes: Integer(fetch_boot_request_value(boot_request, :max_request_head_bytes)),
-          runtime_role: String(fetch_boot_request_value(boot_request, :runtime_role))
+          runtime_role: normalize_runtime_role(fetch_boot_request_value(boot_request, :runtime_role))
         }
       rescue KeyError => e
         raise BootContractError, "missing boot request field: #{e.key}"
@@ -107,6 +107,14 @@ module Vajra
         boot_request.fetch(String(key))
       end
       private_class_method :fetch_boot_request_value
+
+      def normalize_runtime_role(runtime_role)
+        normalized_runtime_role = coerce_contract_string(runtime_role, 'runtime role')
+        raise BootContractError, 'runtime role must not be empty' if normalized_runtime_role.empty?
+
+        normalized_runtime_role
+      end
+      private_class_method :normalize_runtime_role
 
       def normalize_boot_result(result)
         status, role, diagnostic = unpack_result(result)

--- a/gems/vajra/lib/vajra/internal/boot.rb
+++ b/gems/vajra/lib/vajra/internal/boot.rb
@@ -111,7 +111,7 @@ module Vajra
       def normalize_boot_result(result)
         status, role, diagnostic = unpack_result(result)
         normalized_status = normalize_status(status)
-        normalized_role = String(role)
+        normalized_role = coerce_contract_string(role, 'boot role')
         raise BootContractError, 'boot role must not be empty' if normalized_role.empty?
 
         normalized_diagnostic = normalize_diagnostic(diagnostic)
@@ -136,7 +136,7 @@ module Vajra
       private_class_method :unpack_result
 
       def normalize_status(status)
-        normalized_status = String(status)
+        normalized_status = coerce_contract_string(status, 'boot status')
         return normalized_status if STATUSES.value?(normalized_status)
 
         raise BootContractError, "unsupported boot status: #{normalized_status}"
@@ -169,9 +169,16 @@ module Vajra
       private_class_method :diagnostic_values_from
 
       def stringify_diagnostic_values(diagnostic_values)
-        diagnostic_values.map { |value| String(value) }
+        diagnostic_values.map { |value| coerce_contract_string(value, 'boot diagnostic value') }
       end
       private_class_method :stringify_diagnostic_values
+
+      def coerce_contract_string(value, field_name)
+        String(value)
+      rescue TypeError, ArgumentError => e
+        raise BootContractError, "#{field_name} must be coercible to String: #{e.message}"
+      end
+      private_class_method :coerce_contract_string
 
       def invalid_boot_diagnostic!
         raise BootContractError, 'boot diagnostic must be a Hash or 3-item Array'

--- a/gems/vajra/sig/vajra/internal/boot.rbs
+++ b/gems/vajra/sig/vajra/internal/boot.rbs
@@ -43,6 +43,7 @@ module Vajra
       interface _BootCoordinator
         def call: (coordinator_boot_request) -> (boot_result_hash | raw_boot_result | raw_boot_status)
       end
+      type boot_coordinator = _BootCoordinator | Method
 
       STATUSES: Hash[Symbol, String]
       SINGLE_PROCESS_BOOTSTRAP_ROLE: String
@@ -50,7 +51,7 @@ module Vajra
       class BootContractError < StandardError
       end
 
-      def self.install!: (?_BootCoordinator) -> _BootCoordinator
+      def self.install!: (?boot_coordinator) -> boot_coordinator
       def self.uninstall!: () -> nil
       def self.installed?: () -> bool
       def self.call: (boot_request) -> boot_result

--- a/gems/vajra/sig/vajra/internal/boot.rbs
+++ b/gems/vajra/sig/vajra/internal/boot.rbs
@@ -8,15 +8,16 @@ module Vajra
     module Boot
       type boot_status = "ready" | "failed" | "pending"
       type boot_diagnostic = [String, String, String]
+      type boot_request = Hash[Symbol | String, String | Integer]
       type boot_result = [boot_status, String, boot_diagnostic?]
-
-      interface _BootRequest
-        def key?: (Symbol | String) -> bool
-        def fetch: (Symbol | String) -> (String | Integer)
-      end
+      type boot_result_hash = {
+        status: boot_status,
+        role: String,
+        diagnostic: boot_diagnostic?
+      }
 
       interface _BootCoordinator
-        def call: (_BootRequest) -> (boot_result | boot_status)
+        def call: (boot_request) -> (boot_result_hash | boot_result | boot_status)
       end
 
       STATUSES: Hash[Symbol, String]
@@ -28,7 +29,7 @@ module Vajra
       def self.install!: (?_BootCoordinator) -> _BootCoordinator
       def self.uninstall!: () -> nil
       def self.installed?: () -> bool
-      def self.call: (_BootRequest) -> boot_result
+      def self.call: (boot_request) -> boot_result
       def self.__native_set_boot_callback__: (Proc | nil) -> (Proc | nil)
     end
   end

--- a/gems/vajra/sig/vajra/internal/boot.rbs
+++ b/gems/vajra/sig/vajra/internal/boot.rbs
@@ -9,6 +9,11 @@ module Vajra
       type boot_status = "ready" | "failed" | "pending"
       type boot_diagnostic = [String, String, String]
       type boot_request = Hash[Symbol | String, String | Integer]
+      type coordinator_boot_request = {
+        port: Integer,
+        max_request_head_bytes: Integer,
+        runtime_role: String
+      }
       type boot_result = [boot_status, String, boot_diagnostic?]
       type raw_boot_status = boot_status | :ready | :failed | :pending
       type raw_boot_diagnostic_value = String | Symbol | Integer
@@ -36,7 +41,7 @@ module Vajra
       }
 
       interface _BootCoordinator
-        def call: (boot_request) -> (boot_result_hash | raw_boot_result | raw_boot_status)
+        def call: (coordinator_boot_request) -> (boot_result_hash | raw_boot_result | raw_boot_status)
       end
 
       STATUSES: Hash[Symbol, String]

--- a/gems/vajra/sig/vajra/internal/boot.rbs
+++ b/gems/vajra/sig/vajra/internal/boot.rbs
@@ -10,14 +10,22 @@ module Vajra
       type boot_diagnostic = [String, String, String]
       type boot_request = Hash[Symbol | String, String | Integer]
       type boot_result = [boot_status, String, boot_diagnostic?]
+      type raw_boot_status = boot_status | :ready | :failed | :pending
+      type raw_boot_diagnostic_hash = {
+        code: String | Symbol | Integer,
+        category: String | Symbol | Integer,
+        message: String | Symbol | Integer
+      }
+      type raw_boot_diagnostic = boot_diagnostic | raw_boot_diagnostic_hash
+      type raw_boot_result = [raw_boot_status, String | Symbol | Integer, raw_boot_diagnostic?]
       type boot_result_hash = {
-        status: boot_status,
-        role: String,
-        diagnostic: boot_diagnostic?
+        status: raw_boot_status,
+        role: String | Symbol | Integer,
+        ?diagnostic: raw_boot_diagnostic?
       }
 
       interface _BootCoordinator
-        def call: (boot_request) -> (boot_result_hash | boot_result | boot_status)
+        def call: (boot_request) -> (boot_result_hash | raw_boot_result | raw_boot_status)
       end
 
       STATUSES: Hash[Symbol, String]

--- a/gems/vajra/sig/vajra/internal/boot.rbs
+++ b/gems/vajra/sig/vajra/internal/boot.rbs
@@ -11,17 +11,28 @@ module Vajra
       type boot_request = Hash[Symbol | String, String | Integer]
       type boot_result = [boot_status, String, boot_diagnostic?]
       type raw_boot_status = boot_status | :ready | :failed | :pending
+      type raw_boot_diagnostic_value = String | Symbol | Integer
+      type raw_boot_diagnostic_array = [
+        raw_boot_diagnostic_value,
+        raw_boot_diagnostic_value,
+        raw_boot_diagnostic_value
+      ]
       type raw_boot_diagnostic_hash = {
-        code: String | Symbol | Integer,
-        category: String | Symbol | Integer,
-        message: String | Symbol | Integer
+        code: raw_boot_diagnostic_value,
+        category: raw_boot_diagnostic_value,
+        message: raw_boot_diagnostic_value
       }
-      type raw_boot_diagnostic = boot_diagnostic | raw_boot_diagnostic_hash
+      type raw_boot_diagnostic = raw_boot_diagnostic_array | raw_boot_diagnostic_hash
       type raw_boot_result = [raw_boot_status, String | Symbol | Integer, raw_boot_diagnostic?]
-      type boot_result_hash = {
+      type boot_result_hash = boot_result_hash_without_diagnostic | boot_result_hash_with_diagnostic
+      type boot_result_hash_without_diagnostic = {
+        status: raw_boot_status,
+        role: String | Symbol | Integer
+      }
+      type boot_result_hash_with_diagnostic = {
         status: raw_boot_status,
         role: String | Symbol | Integer,
-        ?diagnostic: raw_boot_diagnostic?
+        diagnostic: raw_boot_diagnostic?
       }
 
       interface _BootCoordinator

--- a/gems/vajra/sig/vajra/internal/boot.rbs
+++ b/gems/vajra/sig/vajra/internal/boot.rbs
@@ -1,0 +1,35 @@
+# Copyright Codevedas Inc. 2025-present
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+module Vajra
+  module Internal
+    module Boot
+      type boot_status = "ready" | "failed" | "pending"
+      type boot_diagnostic = [String, String, String]
+      type boot_result = [boot_status, String, boot_diagnostic?]
+
+      interface _BootRequest
+        def key?: (Symbol | String) -> bool
+        def fetch: (Symbol | String) -> (String | Integer)
+      end
+
+      interface _BootCoordinator
+        def call: (_BootRequest) -> (boot_result | boot_status)
+      end
+
+      STATUSES: Hash[Symbol, String]
+      SINGLE_PROCESS_BOOTSTRAP_ROLE: String
+
+      class BootContractError < StandardError
+      end
+
+      def self.install!: (?_BootCoordinator) -> _BootCoordinator
+      def self.uninstall!: () -> nil
+      def self.installed?: () -> bool
+      def self.call: (_BootRequest) -> boot_result
+      def self.__native_set_boot_callback__: (Proc | nil) -> (Proc | nil)
+    end
+  end
+end

--- a/gems/vajra/spec/cpp/lifecycle_controller_test.cpp
+++ b/gems/vajra/spec/cpp/lifecycle_controller_test.cpp
@@ -210,6 +210,41 @@ namespace VajraSpecCpp
       }
     }
 
+    void test_lifecycle_controller_allows_boot_ready_after_drain_when_listener_is_bound()
+    {
+      Vajra::lifecycle::Controller controller;
+      std::vector<Vajra::lifecycle::HookPoint> hook_points;
+      controller.set_observer([&](Vajra::lifecycle::HookPoint hook_point, const Vajra::lifecycle::Snapshot &) {
+        hook_points.push_back(hook_point);
+      });
+
+      if (!controller.begin_startup() || !controller.mark_listening(7, 3000))
+      {
+        fail("lifecycle controller failed to reach listening before drain");
+      }
+
+      controller.request_stop(Vajra::lifecycle::StopReason::programmatic_stop);
+      controller.mark_boot_ready();
+
+      const Vajra::lifecycle::Snapshot snapshot = controller.snapshot();
+      if (snapshot.state != Vajra::lifecycle::State::draining ||
+          snapshot.boot_readiness != Vajra::lifecycle::BootReadiness::ready ||
+          snapshot.last_stop_reason != Vajra::lifecycle::StopReason::programmatic_stop ||
+          !snapshot.listener_owned)
+      {
+        fail("lifecycle controller did not preserve boot readiness during drain after listener bind");
+      }
+
+      const std::vector<Vajra::lifecycle::HookPoint> expected_hooks = {
+          Vajra::lifecycle::HookPoint::drain_requested,
+          Vajra::lifecycle::HookPoint::boot_complete,
+      };
+      if (hook_points != expected_hooks)
+      {
+        fail("lifecycle controller did not emit boot_complete after drain when listener was already bound");
+      }
+    }
+
     void test_lifecycle_controller_tracks_stop_before_start_separately_from_stopped_state()
     {
       Vajra::lifecycle::Controller controller;
@@ -250,6 +285,7 @@ namespace VajraSpecCpp
     test_lifecycle_controller_stop_requests_are_idempotent();
     test_lifecycle_controller_ignores_serving_transition_after_drain_begins();
     test_lifecycle_controller_rejects_listening_completion_after_drain_begins();
+    test_lifecycle_controller_allows_boot_ready_after_drain_when_listener_is_bound();
     test_lifecycle_controller_tracks_stop_before_start_separately_from_stopped_state();
   }
 }

--- a/gems/vajra/spec/cpp/lifecycle_controller_test.cpp
+++ b/gems/vajra/spec/cpp/lifecycle_controller_test.cpp
@@ -26,12 +26,14 @@ namespace VajraSpecCpp
       {
         fail("lifecycle controller failed to begin normal startup");
       }
+      controller.mark_boot_ready();
       controller.mark_serving();
       controller.request_stop(Vajra::lifecycle::StopReason::programmatic_stop);
       controller.finish_stop();
 
       const Vajra::lifecycle::Snapshot snapshot = controller.snapshot();
       if (snapshot.state != Vajra::lifecycle::State::stopped ||
+          snapshot.boot_readiness != Vajra::lifecycle::BootReadiness::pending ||
           snapshot.last_stop_reason != Vajra::lifecycle::StopReason::programmatic_stop ||
           snapshot.listener_owned)
       {
@@ -76,6 +78,40 @@ namespace VajraSpecCpp
       catch (const std::logic_error &)
       {
       }
+
+      try
+      {
+        controller.mark_boot_ready();
+        fail("lifecycle controller accepted boot-ready before listening");
+      }
+      catch (const std::logic_error &)
+      {
+      }
+    }
+
+    void test_lifecycle_controller_emits_boot_complete_only_after_boot_ready()
+    {
+      Vajra::lifecycle::Controller controller;
+      std::vector<Vajra::lifecycle::HookPoint> hook_points;
+      controller.set_observer([&](Vajra::lifecycle::HookPoint hook_point, const Vajra::lifecycle::Snapshot &) {
+        hook_points.push_back(hook_point);
+      });
+
+      if (!controller.begin_startup() || !controller.mark_listening(7, 3000))
+      {
+        fail("lifecycle controller failed to reach listening before boot-ready");
+      }
+
+      if (!hook_points.empty())
+      {
+        fail("lifecycle controller emitted boot_complete before boot-ready");
+      }
+
+      controller.mark_boot_ready();
+      if (hook_points != std::vector<Vajra::lifecycle::HookPoint>{Vajra::lifecycle::HookPoint::boot_complete})
+      {
+        fail("lifecycle controller did not emit boot_complete when boot-ready was reported");
+      }
     }
 
     void test_lifecycle_controller_preserves_failure_state()
@@ -94,6 +130,7 @@ namespace VajraSpecCpp
 
       const Vajra::lifecycle::Snapshot snapshot = controller.snapshot();
       if (snapshot.state != Vajra::lifecycle::State::failed ||
+          snapshot.boot_readiness != Vajra::lifecycle::BootReadiness::failed ||
           snapshot.last_stop_reason != Vajra::lifecycle::StopReason::startup_failure ||
           snapshot.listener_owned)
       {
@@ -116,6 +153,7 @@ namespace VajraSpecCpp
       {
         fail("lifecycle controller failed to begin normal startup");
       }
+      controller.mark_boot_ready();
       controller.request_stop(Vajra::lifecycle::StopReason::signal_shutdown);
       controller.request_stop(Vajra::lifecycle::StopReason::programmatic_stop);
       controller.finish_stop();
@@ -139,6 +177,7 @@ namespace VajraSpecCpp
 
       const Vajra::lifecycle::Snapshot snapshot = controller.snapshot();
       if (snapshot.state != Vajra::lifecycle::State::draining ||
+          snapshot.boot_readiness != Vajra::lifecycle::BootReadiness::pending ||
           snapshot.last_stop_reason != Vajra::lifecycle::StopReason::programmatic_stop)
       {
         fail("lifecycle controller did not preserve draining state when serving raced with stop");
@@ -161,6 +200,7 @@ namespace VajraSpecCpp
 
       const Vajra::lifecycle::Snapshot snapshot = controller.snapshot();
       if (snapshot.state != Vajra::lifecycle::State::draining ||
+          snapshot.boot_readiness != Vajra::lifecycle::BootReadiness::pending ||
           snapshot.last_stop_reason != Vajra::lifecycle::StopReason::programmatic_stop ||
           snapshot.port != 3000 ||
           snapshot.listener_fd != 7 ||
@@ -177,6 +217,7 @@ namespace VajraSpecCpp
 
       const Vajra::lifecycle::Snapshot requested_snapshot = controller.snapshot();
       if (requested_snapshot.state != Vajra::lifecycle::State::stopped ||
+          requested_snapshot.boot_readiness != Vajra::lifecycle::BootReadiness::pending ||
           requested_snapshot.last_stop_reason != Vajra::lifecycle::StopReason::programmatic_stop ||
           controller.begin_startup())
       {
@@ -204,6 +245,7 @@ namespace VajraSpecCpp
   {
     test_lifecycle_controller_tracks_normal_transitions();
     test_lifecycle_controller_rejects_invalid_transitions();
+    test_lifecycle_controller_emits_boot_complete_only_after_boot_ready();
     test_lifecycle_controller_preserves_failure_state();
     test_lifecycle_controller_stop_requests_are_idempotent();
     test_lifecycle_controller_ignores_serving_transition_after_drain_begins();

--- a/gems/vajra/spec/e2e/vajra/configuration_spec.rb
+++ b/gems/vajra/spec/e2e/vajra/configuration_spec.rb
@@ -75,6 +75,26 @@ RSpec.describe 'Vajra configuration', :e2e, :integration do # rubocop:disable RS
     )
   end
 
+  it 'fails startup with actionable Ruby boot diagnostics' do
+    failure = startup_failure_with_inline_script(<<~RUBY)
+      require "vajra"
+
+      Vajra::Internal::Boot.install!(lambda do |_boot_request|
+        raise "boot exploded"
+      end)
+
+      Vajra.start
+    RUBY
+
+    expect(failure).to match(
+      exitstatus: be_positive,
+      output: a_string_including(
+        'Unable to start Vajra: Ruby boot failed (boot_callback_error/boot): RuntimeError: boot exploded'
+      )
+    )
+    expect(failure[:output]).not_to include('listening on port')
+  end
+
   it 'lets Ruby configure the listener port when VAJRA_PORT is unset' do
     request = request_response_from_inline_start(env: { 'RUBY_PORT' => disposable_listener_port.to_s })
 

--- a/gems/vajra/spec/e2e/vajra/lifecycle_spec.rb
+++ b/gems/vajra/spec/e2e/vajra/lifecycle_spec.rb
@@ -17,7 +17,9 @@ RSpec.describe 'Vajra lifecycle', :e2e, :integration do # rubocop:disable RSpec/
       '[Vajra][lifecycle]',
       'event=drain_requested',
       'event=stop_completed',
+      'boot_status=ready',
       'mode=single_process',
+      'runtime_role=single_process_bootstrap',
       'worker_processes=0'
     )
 

--- a/gems/vajra/spec/vajra/internal/boot_spec.rb
+++ b/gems/vajra/spec/vajra/internal/boot_spec.rb
@@ -268,6 +268,48 @@ RSpec.describe Vajra::Internal::Boot do
     )
   end
 
+  it 'returns a contract failure when boot status coercion raises' do
+    bad_status = Object.new
+    def bad_status.to_s
+      raise TypeError, 'status boom'
+    end
+
+    described_class.install!(->(_boot_request) { [bad_status, 'custom_bootstrap', nil] })
+
+    status, role, diagnostic = described_class.call(
+      port: 3000,
+      max_request_head_bytes: 16_384,
+      runtime_role: 'single_process_bootstrap'
+    )
+
+    expect(status).to eq('failed')
+    expect(role).to eq('single_process_bootstrap')
+    expect(diagnostic).to eq(
+      ['invalid_boot_contract', 'contract', 'Vajra::Internal::Boot::BootContractError: boot status must be coercible to String: status boom']
+    )
+  end
+
+  it 'returns a contract failure when boot role coercion raises' do
+    bad_role = Object.new
+    def bad_role.to_s
+      raise TypeError, 'role boom'
+    end
+
+    described_class.install!(->(_boot_request) { ['ready', bad_role, nil] })
+
+    status, role, diagnostic = described_class.call(
+      port: 3000,
+      max_request_head_bytes: 16_384,
+      runtime_role: 'single_process_bootstrap'
+    )
+
+    expect(status).to eq('failed')
+    expect(role).to eq('single_process_bootstrap')
+    expect(diagnostic).to eq(
+      ['invalid_boot_contract', 'contract', 'Vajra::Internal::Boot::BootContractError: boot role must be coercible to String: role boom']
+    )
+  end
+
   it 'returns a contract failure when the coordinator returns an invalid diagnostic shape' do
     described_class.install!(lambda do |_boot_request|
       { status: 'failed', role: 'custom_bootstrap', diagnostic: 'bad diagnostic' }
@@ -283,6 +325,29 @@ RSpec.describe Vajra::Internal::Boot do
     expect(role).to eq('single_process_bootstrap')
     expect(diagnostic).to eq(
       ['invalid_boot_contract', 'contract', 'Vajra::Internal::Boot::BootContractError: boot diagnostic must be a Hash or 3-item Array']
+    )
+  end
+
+  it 'returns a contract failure when diagnostic value coercion raises' do
+    bad_value = Object.new
+    def bad_value.to_s
+      raise TypeError, 'diagnostic boom'
+    end
+
+    described_class.install!(lambda do |_boot_request|
+      { status: 'failed', role: 'custom_bootstrap', diagnostic: [:boot_failed, :boot, bad_value] }
+    end)
+
+    status, role, diagnostic = described_class.call(
+      port: 3000,
+      max_request_head_bytes: 16_384,
+      runtime_role: 'single_process_bootstrap'
+    )
+
+    expect(status).to eq('failed')
+    expect(role).to eq('single_process_bootstrap')
+    expect(diagnostic).to eq(
+      ['invalid_boot_contract', 'contract', 'Vajra::Internal::Boot::BootContractError: boot diagnostic value must be coercible to String: diagnostic boom']
     )
   end
 

--- a/gems/vajra/spec/vajra/internal/boot_spec.rb
+++ b/gems/vajra/spec/vajra/internal/boot_spec.rb
@@ -33,6 +33,29 @@ RSpec.describe Vajra::Internal::Boot do
       .to raise_error(TypeError, 'boot coordinator must respond to #call')
   end
 
+  it 'reraises unrelated NameError values from coordinator validation' do
+    coordinator = Class.new do
+      def method(_name)
+        raise NameError.new('unexpected missing method', :unexpected_method)
+      end
+    end.new
+
+    expect { described_class.install!(coordinator) }
+      .to raise_error(NameError, /unexpected missing method/)
+  end
+
+  it 'does not rewrite unrelated NameError failures as coordinator type errors' do
+    allow(described_class).to receive(:__native_set_boot_callback__).and_raise(
+      NoMethodError,
+      "undefined method `__native_set_boot_callback__'"
+    )
+
+    expect { described_class.install!(->(_boot_request) { 'ready' }) }
+      .to raise_error(NoMethodError, /__native_set_boot_callback__/)
+
+    allow(described_class).to receive(:__native_set_boot_callback__).and_call_original
+  end
+
   it 'normalizes a successful boot result and boot request' do
     captured_request = nil
     described_class.install!(lambda { |boot_request|

--- a/gems/vajra/spec/vajra/internal/boot_spec.rb
+++ b/gems/vajra/spec/vajra/internal/boot_spec.rb
@@ -213,6 +213,22 @@ RSpec.describe Vajra::Internal::Boot do
     )
   end
 
+  it 'returns a contract failure when a failed boot result omits diagnostics' do
+    described_class.install!(->(_boot_request) { { status: 'failed', role: 'custom_bootstrap' } })
+
+    status, role, diagnostic = described_class.call(
+      port: 3000,
+      max_request_head_bytes: 16_384,
+      runtime_role: 'single_process_bootstrap'
+    )
+
+    expect(status).to eq('failed')
+    expect(role).to eq('single_process_bootstrap')
+    expect(diagnostic).to eq(
+      ['invalid_boot_contract', 'contract', 'Vajra::Internal::Boot::BootContractError: failed boot results must include diagnostic details']
+    )
+  end
+
   it 'returns a contract failure when the coordinator returns an empty role' do
     described_class.install!(->(_boot_request) { { status: 'ready', role: '' } })
 

--- a/gems/vajra/spec/vajra/internal/boot_spec.rb
+++ b/gems/vajra/spec/vajra/internal/boot_spec.rb
@@ -28,6 +28,13 @@ RSpec.describe Vajra::Internal::Boot do
     expect(described_class.install!(coordinator)).to equal(coordinator)
   end
 
+  it 'returns the default method coordinator when install! is called without arguments' do
+    coordinator = described_class.install!
+
+    expect(coordinator).to be_a(Method)
+    expect(coordinator.name).to eq(:default_coordinator)
+  end
+
   it 'rejects non-callable boot coordinators' do
     expect { described_class.install!(Object.new) }
       .to raise_error(TypeError, 'boot coordinator must respond to #call')

--- a/gems/vajra/spec/vajra/internal/boot_spec.rb
+++ b/gems/vajra/spec/vajra/internal/boot_spec.rb
@@ -56,6 +56,31 @@ RSpec.describe Vajra::Internal::Boot do
     )
   end
 
+  it 'accepts string-keyed boot requests without symbolizing arbitrary keys' do
+    captured_request = nil
+    described_class.install!(lambda { |boot_request|
+      captured_request = boot_request
+      { status: :ready, role: 'single_process_bootstrap' }
+    })
+
+    status, role, diagnostic = described_class.call(
+      'port' => 3000,
+      'max_request_head_bytes' => 16_384,
+      'runtime_role' => 'single_process_bootstrap',
+      'unexpected_user_key' => 'ignored'
+    )
+
+    expect(status).to eq('ready')
+    expect(role).to eq('single_process_bootstrap')
+    expect(diagnostic).to be_nil
+    expect(captured_request).to include(
+      port: 3000,
+      max_request_head_bytes: 16_384,
+      runtime_role: 'single_process_bootstrap'
+    )
+    expect(captured_request).not_to have_key(:unexpected_user_key)
+  end
+
   it 'returns a structured failed result when the coordinator raises' do
     described_class.install!(->(_boot_request) { raise 'boot exploded' })
 

--- a/gems/vajra/spec/vajra/internal/boot_spec.rb
+++ b/gems/vajra/spec/vajra/internal/boot_spec.rb
@@ -1,0 +1,294 @@
+# frozen_string_literal: true
+
+# Copyright Codevedas Inc. 2025-present
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+RSpec.describe Vajra::Internal::Boot do
+  after do
+    described_class.install!
+  end
+
+  it 'tracks whether a boot coordinator is installed' do
+    expect(described_class.installed?).to be(true)
+
+    described_class.uninstall!
+
+    expect(described_class.installed?).to be(false)
+  end
+
+  it 'accepts callable boot coordinator objects' do
+    coordinator = Class.new do
+      def call(_boot_request)
+        { status: 'ready', role: 'custom_bootstrap' }
+      end
+    end.new
+
+    expect(described_class.install!(coordinator)).to equal(coordinator)
+  end
+
+  it 'rejects non-callable boot coordinators' do
+    expect { described_class.install!(Object.new) }
+      .to raise_error(TypeError, 'boot coordinator must respond to #call')
+  end
+
+  it 'normalizes a successful boot result and boot request' do
+    captured_request = nil
+    described_class.install!(lambda { |boot_request|
+      captured_request = boot_request
+      { status: :ready, role: 'single_process_bootstrap' }
+    })
+
+    status, role, diagnostic = described_class.call(
+      port: 3000,
+      max_request_head_bytes: 16_384,
+      runtime_role: 'single_process_bootstrap'
+    )
+
+    expect(status).to eq('ready')
+    expect(role).to eq('single_process_bootstrap')
+    expect(diagnostic).to be_nil
+    expect(captured_request).to eq(
+      port: 3000,
+      max_request_head_bytes: 16_384,
+      runtime_role: 'single_process_bootstrap'
+    )
+  end
+
+  it 'returns a structured failed result when the coordinator raises' do
+    described_class.install!(->(_boot_request) { raise 'boot exploded' })
+
+    status, role, diagnostic = described_class.call(
+      port: 3000,
+      max_request_head_bytes: 16_384,
+      runtime_role: 'single_process_bootstrap'
+    )
+
+    expect(status).to eq('failed')
+    expect(role).to eq('single_process_bootstrap')
+    expect(diagnostic).to eq(
+      ['boot_callback_error', 'boot', 'RuntimeError: boot exploded']
+    )
+  end
+
+  it 'uses the default coordinator when install! is called without arguments' do
+    described_class.install!
+
+    status, role, diagnostic = described_class.call(
+      port: 3000,
+      max_request_head_bytes: 16_384,
+      runtime_role: 'ignored'
+    )
+
+    expect(status).to eq('ready')
+    expect(role).to eq('single_process_bootstrap')
+    expect(diagnostic).to be_nil
+  end
+
+  it 'accepts bare status values from the coordinator' do
+    described_class.install!(->(_boot_request) { :pending })
+
+    status, role, diagnostic = described_class.call(
+      port: 3000,
+      max_request_head_bytes: 16_384,
+      runtime_role: 'single_process_bootstrap'
+    )
+
+    expect(status).to eq('pending')
+    expect(role).to eq('single_process_bootstrap')
+    expect(diagnostic).to be_nil
+  end
+
+  it 'accepts array boot results with array diagnostics' do
+    described_class.install!(lambda do |_boot_request|
+      ['failed', 'custom_bootstrap', ['boot_failed', 'boot', 'failed on purpose']]
+    end)
+
+    status, role, diagnostic = described_class.call(
+      port: 3000,
+      max_request_head_bytes: 16_384,
+      runtime_role: 'single_process_bootstrap'
+    )
+
+    expect(status).to eq('failed')
+    expect(role).to eq('custom_bootstrap')
+    expect(diagnostic).to eq(['boot_failed', 'boot', 'failed on purpose'])
+  end
+
+  it 'accepts hash diagnostics and stringifies their fields' do
+    described_class.install!(lambda do |_boot_request|
+      {
+        status: 'failed',
+        role: 'custom_bootstrap',
+        diagnostic: {
+          code: :boot_failed,
+          category: :boot,
+          message: 123
+        }
+      }
+    end)
+
+    status, role, diagnostic = described_class.call(
+      port: 3000,
+      max_request_head_bytes: 16_384,
+      runtime_role: 'single_process_bootstrap'
+    )
+
+    expect(status).to eq('failed')
+    expect(role).to eq('custom_bootstrap')
+    expect(diagnostic).to eq(%w[boot_failed boot 123])
+  end
+
+  it 'returns a contract failure when the coordinator returns an invalid result' do
+    described_class.install!(->(_boot_request) { [:unknown, 'single_process_bootstrap', nil] })
+
+    status, role, diagnostic = described_class.call(
+      port: 3000,
+      max_request_head_bytes: 16_384,
+      runtime_role: 'single_process_bootstrap'
+    )
+
+    expect(status).to eq('failed')
+    expect(role).to eq('single_process_bootstrap')
+    expect(diagnostic).to eq(
+      ['invalid_boot_contract', 'contract', 'Vajra::Internal::Boot::BootContractError: unsupported boot status: unknown']
+    )
+  end
+
+  it 'returns a contract failure when the coordinator returns an unsupported result type' do
+    described_class.install!(->(_boot_request) { 123 })
+
+    status, role, diagnostic = described_class.call(
+      port: 3000,
+      max_request_head_bytes: 16_384,
+      runtime_role: 'single_process_bootstrap'
+    )
+
+    expect(status).to eq('failed')
+    expect(role).to eq('single_process_bootstrap')
+    expect(diagnostic).to eq(
+      ['invalid_boot_contract', 'contract', 'Vajra::Internal::Boot::BootContractError: boot coordinator must return a boot result']
+    )
+  end
+
+  it 'returns a contract failure when the coordinator omits boot result fields' do
+    described_class.install!(->(_boot_request) { { status: 'ready' } })
+
+    status, role, diagnostic = described_class.call(
+      port: 3000,
+      max_request_head_bytes: 16_384,
+      runtime_role: 'single_process_bootstrap'
+    )
+
+    expect(status).to eq('failed')
+    expect(role).to eq('single_process_bootstrap')
+    expect(diagnostic).to eq(
+      ['invalid_boot_contract', 'contract', 'Vajra::Internal::Boot::BootContractError: missing boot result field: role']
+    )
+  end
+
+  it 'returns a contract failure when the coordinator returns an empty role' do
+    described_class.install!(->(_boot_request) { { status: 'ready', role: '' } })
+
+    status, role, diagnostic = described_class.call(
+      port: 3000,
+      max_request_head_bytes: 16_384,
+      runtime_role: 'single_process_bootstrap'
+    )
+
+    expect(status).to eq('failed')
+    expect(role).to eq('single_process_bootstrap')
+    expect(diagnostic).to eq(
+      ['invalid_boot_contract', 'contract', 'Vajra::Internal::Boot::BootContractError: boot role must not be empty']
+    )
+  end
+
+  it 'returns a contract failure when the coordinator returns an invalid diagnostic shape' do
+    described_class.install!(lambda do |_boot_request|
+      { status: 'failed', role: 'custom_bootstrap', diagnostic: 'bad diagnostic' }
+    end)
+
+    status, role, diagnostic = described_class.call(
+      port: 3000,
+      max_request_head_bytes: 16_384,
+      runtime_role: 'single_process_bootstrap'
+    )
+
+    expect(status).to eq('failed')
+    expect(role).to eq('single_process_bootstrap')
+    expect(diagnostic).to eq(
+      ['invalid_boot_contract', 'contract', 'Vajra::Internal::Boot::BootContractError: boot diagnostic must be a Hash or 3-item Array']
+    )
+  end
+
+  it 'returns a contract failure when the coordinator returns a short diagnostic array' do
+    described_class.install!(lambda do |_boot_request|
+      { status: 'failed', role: 'custom_bootstrap', diagnostic: %w[boot_failed boot] }
+    end)
+
+    status, role, diagnostic = described_class.call(
+      port: 3000,
+      max_request_head_bytes: 16_384,
+      runtime_role: 'single_process_bootstrap'
+    )
+
+    expect(status).to eq('failed')
+    expect(role).to eq('single_process_bootstrap')
+    expect(diagnostic).to eq(
+      ['invalid_boot_contract', 'contract', 'Vajra::Internal::Boot::BootContractError: boot diagnostic must be a Hash or 3-item Array']
+    )
+  end
+
+  it 'returns a contract failure when diagnostic fields are missing' do
+    described_class.install!(lambda do |_boot_request|
+      { status: 'failed', role: 'custom_bootstrap', diagnostic: { code: 'boot_failed' } }
+    end)
+
+    status, role, diagnostic = described_class.call(
+      port: 3000,
+      max_request_head_bytes: 16_384,
+      runtime_role: 'single_process_bootstrap'
+    )
+
+    expect(status).to eq('failed')
+    expect(role).to eq('single_process_bootstrap')
+    expect(diagnostic).to eq(
+      ['invalid_boot_contract', 'contract', 'Vajra::Internal::Boot::BootContractError: missing boot diagnostic field: category']
+    )
+  end
+
+  it 'returns a contract failure for malformed boot requests' do
+    status, role, diagnostic = described_class.call([])
+
+    expect(status).to eq('failed')
+    expect(role).to eq('single_process_bootstrap')
+    expect(diagnostic).to eq(
+      ['invalid_boot_contract', 'contract', 'Vajra::Internal::Boot::BootContractError: boot request must be a Hash']
+    )
+  end
+
+  it 'returns a contract failure for boot requests with missing or invalid fields' do
+    missing_status, missing_role, missing_diagnostic = described_class.call(
+      port: 3000,
+      runtime_role: 'single_process_bootstrap'
+    )
+    invalid_status, invalid_role, invalid_diagnostic = described_class.call(
+      port: 3000,
+      max_request_head_bytes: 'invalid',
+      runtime_role: 'single_process_bootstrap'
+    )
+
+    expect(missing_status).to eq('failed')
+    expect(missing_role).to eq('single_process_bootstrap')
+    expect(missing_diagnostic).to eq(
+      ['invalid_boot_contract', 'contract', 'Vajra::Internal::Boot::BootContractError: missing boot request field: max_request_head_bytes']
+    )
+
+    expect(invalid_status).to eq('failed')
+    expect(invalid_role).to eq('single_process_bootstrap')
+    expect(invalid_diagnostic).to eq(
+      ['invalid_boot_contract', 'contract', 'Vajra::Internal::Boot::BootContractError: invalid value for Integer(): "invalid"']
+    )
+  end
+end

--- a/gems/vajra/spec/vajra/internal/boot_spec.rb
+++ b/gems/vajra/spec/vajra/internal/boot_spec.rb
@@ -63,6 +63,21 @@ RSpec.describe Vajra::Internal::Boot do
     allow(described_class).to receive(:__native_set_boot_callback__).and_call_original
   end
 
+  it 'does not mark the boot coordinator installed when native callback registration fails' do
+    previous_coordinator = described_class.send(:configured_coordinator)
+
+    allow(described_class).to receive(:__native_set_boot_callback__).and_raise(
+      RuntimeError,
+      'native callback registration failed'
+    )
+
+    expect { described_class.install!(->(_boot_request) { 'ready' }) }
+      .to raise_error(RuntimeError, /native callback registration failed/)
+
+    expect(described_class.send(:configured_coordinator)).to equal(previous_coordinator)
+    allow(described_class).to receive(:__native_set_boot_callback__).and_call_original
+  end
+
   it 'normalizes a successful boot result and boot request' do
     captured_request = nil
     described_class.install!(lambda { |boot_request|
@@ -425,6 +440,39 @@ RSpec.describe Vajra::Internal::Boot do
     expect(invalid_role).to eq('single_process_bootstrap')
     expect(invalid_diagnostic).to eq(
       ['invalid_boot_contract', 'contract', 'Vajra::Internal::Boot::BootContractError: invalid value for Integer(): "invalid"']
+    )
+  end
+
+  it 'returns a contract failure for boot requests with an empty runtime role' do
+    status, role, diagnostic = described_class.call(
+      port: 3000,
+      max_request_head_bytes: 16_384,
+      runtime_role: ''
+    )
+
+    expect(status).to eq('failed')
+    expect(role).to eq('single_process_bootstrap')
+    expect(diagnostic).to eq(
+      ['invalid_boot_contract', 'contract', 'Vajra::Internal::Boot::BootContractError: runtime role must not be empty']
+    )
+  end
+
+  it 'returns a contract failure for boot requests when runtime role coercion raises' do
+    bad_runtime_role = Object.new
+    def bad_runtime_role.to_s
+      raise TypeError, 'runtime role boom'
+    end
+
+    status, role, diagnostic = described_class.call(
+      port: 3000,
+      max_request_head_bytes: 16_384,
+      runtime_role: bad_runtime_role
+    )
+
+    expect(status).to eq('failed')
+    expect(role).to eq('single_process_bootstrap')
+    expect(diagnostic).to eq(
+      ['invalid_boot_contract', 'contract', 'Vajra::Internal::Boot::BootContractError: runtime role must be coercible to String: runtime role boom']
     )
   end
 end

--- a/scripts/run-rbs-all
+++ b/scripts/run-rbs-all
@@ -19,7 +19,7 @@ run_suite() {
   fi
 
   if grep -R -n -w -E 'untyped|top|Object|BasicObject' "${REPO_ROOT}/${suite_dir}/sig" >/dev/null 2>&1; then
-    echo "Strict RBS check failed for ${suite_label}: found forbidden generic types in sig/"
+    echo "Strict RBS check failed for ${suite_label}: found forbidden broad types or placeholders in sig/ (untyped, top, Object, BasicObject)"
     grep -R -n -w -E 'untyped|top|Object|BasicObject' "${REPO_ROOT}/${suite_dir}/sig"
     return 1
   fi


### PR DESCRIPTION
- Introduced BootReadiness enum to track the boot state of the controller.
- Updated Controller class to manage boot readiness states (pending, ready, failed).
- Added mark_boot_ready method to transition the controller to a ready state.
- Modified lifecycle snapshot to include boot readiness information.
- Enhanced logging to reflect boot readiness status during lifecycle events.
- Implemented tests to ensure correct behavior of boot readiness transitions and diagnostics.
- Updated Ruby boot contract to provide actionable diagnostics on failure.

closes: #58