### PR TITLE
feat: enforce worker-only request execution

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,7 @@ Vajra is organized as one gem with one clear runtime boundary.
 
 ## Explore The Docs
 
-- [Getting Started](/getting-started/): repository bootstrap, first validation,
+- [Getting Started](/getting-started/): repository setup, first validation,
   and the fastest reading path through the project
 - [Installation](/installation/): toolchain requirements, native build path,
   artifact expectations, and clean rebuild workflow

--- a/docs/pages/architecture.md
+++ b/docs/pages/architecture.md
@@ -30,8 +30,8 @@ families:
 - protocol and transport extensions such as TLS and HTTP/2
 
 Within the supervision and IPC family, Vajra keeps request-execution framing
-separate from control and lifecycle framing so future Rack execution, worker
-coordination, and observability work do not collapse into one mixed protocol.
+separate from control and lifecycle framing so Rack execution, worker
+coordination, and observability do not collapse into one mixed protocol.
 
 ## Repository Boundaries
 

--- a/docs/pages/configuration.md
+++ b/docs/pages/configuration.md
@@ -24,9 +24,8 @@ clear ownership boundaries.
 - Ruby toolchain and Bundler environment
 - native compilation toolchain
 - executable startup from `gems/vajra`
-- the default listener port owned by the runtime
-- platform-specific settings within the supported platform surface
-- protocol and transport settings within the supported runtime surface
+- listener port
+- maximum request-head size
 
 ## Build-Time Configuration
 
@@ -43,11 +42,9 @@ compiled artifact lives.
 
 The supported configuration story is organized around these families:
 
-- boot and application entrypoint selection
 - listener and socket behavior
-- worker and scheduling controls as those runtime layers land
-- observability and telemetry outputs
-- protocol- and transport-specific settings only after those milestones ship
+- request parsing limits
+- documented environment overrides for runtime-owned values
 
 ## Runtime Configuration Posture
 
@@ -60,12 +57,12 @@ Framework integration follows an explicit-config-first model:
 
 - application entrypoint and adapter selection should be explicit
 - `VAJRA_`-prefixed environment overrides are part of the supported config path
-- transport, protocol, and platform-specific toggles belong to documented
-  supported surfaces
+- application-owned behavior stays in the application, not in hidden server
+  toggles
 
 ## Precedence Model
 
-The intended precedence model is:
+The precedence model is:
 
 1. explicit server/application configuration
 2. documented `VAJRA_` environment overrides
@@ -74,13 +71,13 @@ The intended precedence model is:
 Operators can reason about effective configuration without reverse-engineering
 source.
 
-## Core Tuning Surfaces
+## Supported Runtime Settings
 
-The core supported tuning surfaces include:
+The supported runtime-owned settings are:
 
-- concurrency/process settings such as `WEB_CONCURRENCY` and `MAX_THREADS`
-- scheduling and admission-control settings
-- observability exporter and verbosity settings
-- protocol and transport settings
+- `port` via `Vajra.start(port: ...)`
+- `max_request_head_bytes` via `Vajra.start(max_request_head_bytes: ...)`
+- `VAJRA_PORT`
+- `VAJRA_MAX_REQUEST_HEAD_BYTES`
 
-These surfaces are documented as part of the supported runtime contract.
+The environment variables override the corresponding Ruby startup options.

--- a/docs/pages/docs-publishing.md
+++ b/docs/pages/docs-publishing.md
@@ -11,7 +11,7 @@ the docs site.
 
 ## Public Hostname
 
-The intended and supported public docs hostname is:
+The supported public docs hostname is:
 
 ```text
 vajra.codevedas.com

--- a/docs/pages/engineering-failure-modes.md
+++ b/docs/pages/engineering-failure-modes.md
@@ -11,7 +11,7 @@ behavior.
 
 ## Early Failure Boundaries
 
-Today the most important failure boundaries are:
+The most important failure boundaries are:
 
 - native extension missing or stale at load time
 - listener bind failure during startup
@@ -36,16 +36,14 @@ Failure and degradation are visible through:
 - boot diagnostics
 - lifecycle transition events
 - structured runtime logs
-- metrics and telemetry hooks as those observability layers land
-- operator-facing visibility into worker, scheduling, and recovery state
+- operator-facing visibility into worker boot and shutdown behavior
 
-## Future Recovery Direction
+## Recovery Direction
 
 This page documents:
 
-- restart semantics
-- worker lifecycle recovery
 - failure isolation boundaries
+- worker boot and worker-exit failure handling
 - control-path timeouts and escalation behavior
 
 ## Known Risks And Unresolved Areas

--- a/docs/pages/engineering-ipc.md
+++ b/docs/pages/engineering-ipc.md
@@ -78,7 +78,7 @@ The IPC contract keeps debugging work explicit instead of hiding protocol state:
 ## Request-Channel Frame Families
 
 The request channel is reserved for application-execution flow between the
-native runtime and later Ruby execution workers.
+native runtime and Ruby execution workers.
 
 | Frame family | Producers | Consumers | Allowed responsibility | Explicitly excluded |
 | --- | --- | --- | --- | --- |
@@ -97,10 +97,10 @@ separate from request execution throughput and request-data ownership.
 | Protocol version negotiation | native runtime, Ruby control peer | control peer, native runtime | protocol version markers, compatibility checks, and unsupported-version outcomes | request payloads, response bodies, application execution data |
 | Process registration and identity | Ruby master or worker, native runtime | control peer, native runtime | process identity, role declaration, registration, and channel attachment state | request execution, telemetry streams, response metadata |
 | Readiness and boot result | Ruby master or worker | native runtime | boot success, boot failure, readiness, and bounded startup diagnostics | request bodies, drain commands, overload reporting |
-| Lifecycle command | native runtime, operator-facing control peer | Ruby control peer, native runtime | drain, stop, shutdown orchestration, and later replacement or restart commands | request dispatch payloads, health snapshots, app response data |
+| Lifecycle command | native runtime, operator-facing control peer | Ruby control peer, native runtime | drain, stop, shutdown orchestration, and replacement or restart commands | request dispatch payloads, health snapshots, app response data |
 | Lifecycle state notification | Ruby control peer, native runtime | control peer, native runtime | state transitions such as booting, ready, draining, stopped, or failed | request or response transport data |
 | Diagnostics and error reporting | Ruby control peer, native runtime | control peer, native runtime | actionable control-path errors, malformed-control-message outcomes, and bounded failure context | request execution payloads, telemetry time series, response bodies |
-| Reserved telemetry and status | Ruby workers, native runtime | control peer, native runtime | future health, overload, queue pressure, and observability signals | request execution commands, lifecycle mutations, app response data |
+| Reserved telemetry and status | Ruby workers, native runtime | control peer, native runtime | health, overload, queue pressure, and observability signals when that family is activated | request execution commands, lifecycle mutations, app response data |
 
 ## Protocol Versioning And Compatibility
 
@@ -144,7 +144,7 @@ surface, not an implementation detail.
   compatibility rule defines how older peers behave
 - optional fields and reserved space are preferred for additive evolution that
   does not change the meaning of existing compatible frames
-- reserved telemetry or future-status families remain unavailable until a
+- reserved telemetry or reserved-status families remain unavailable until a
   versioned contract activates them explicitly
 
 ### Compatibility Ownership

--- a/docs/pages/engineering-runtime.md
+++ b/docs/pages/engineering-runtime.md
@@ -20,13 +20,16 @@ The runtime lifecycle is:
 
 1. Ruby boots the package entrypoint
 2. the native extension is loaded through the canonical require path
-3. the native server instance binds the listener
-4. requests are accepted and handled in the native path
-5. signals initiate shutdown
+3. Ruby preload boot runs in the main process
+4. the main process forks one Ruby worker
+5. the worker reports boot readiness through the control path
+6. the native server instance in the main process binds the listener
+7. requests are accepted in the native path and executed in the worker
+8. signals or programmatic stop initiate shutdown
 
 ## Runtime State Model
 
-The intended runtime state model is explicit and readable:
+The runtime state model is explicit and readable:
 
 - booting
 - listening
@@ -35,25 +38,24 @@ The intended runtime state model is explicit and readable:
 - stopped
 - failed
 
-Supervision preserves those explicit transitions rather than burying lifecycle
-state in incidental flags or incidental file-descriptor ownership.
+The runtime preserves those explicit transitions rather than burying lifecycle
+state in incidental flags or file-descriptor ownership.
 
 ## Supervision Direction
 
-The runtime is single-process and foreground-oriented. Supervision and worker
-lifecycle work extend this documented lifecycle rather than replacing the
-package and load contract underneath it.
+The runtime is foreground-oriented with one controlling process and one Ruby
+worker. The listener, request parsing, and response transport stay in the
+native runtime process; application request execution stays in the Ruby worker.
 
 ## Supervision Expectations
 
 Contributors and operators can reason about:
 
 - preloaded master-versus-worker ownership
-- worker fork/spawn lifecycle
-- task queue and thread lifecycle within a worker
-- how shutdown and replacement flow across the runtime
-- which signals are diagnostics, which are lifecycle transitions, and which are
-  recovery triggers
+- worker fork lifecycle
+- request-channel versus control-channel responsibilities
+- how shutdown flows across the runtime
+- which signals are diagnostics and which are lifecycle transitions
 
 ## Engineering Boundaries
 
@@ -62,8 +64,8 @@ The repo shape answers these questions:
 - where runtime boot begins
 - where listener state lives
 - where diagnostics are emitted
-- where shutdown ownership transitions from Ruby to native code
-- where later supervision can observe lifecycle state without inferring it from listener flags
+- where shutdown ownership transitions from request serving to worker teardown
+- where lifecycle state stays explicit without being inferred from listener flags
 
 The runtime also preserves a hard split between:
 

--- a/docs/pages/integration.md
+++ b/docs/pages/integration.md
@@ -29,6 +29,10 @@ Every supported integration preserves the same high-level contract:
 - the application remains responsible for application semantics
 - Vajra remains responsible for listener lifecycle, request execution entry, and
   runtime ownership
+- the native runtime owns accepted connections and response transport while Ruby
+  workers execute application requests
+- the Ruby master stays on boot and control responsibilities only; same-process
+  callback execution is bootstrap plumbing, not supported runtime architecture
 - boot failures identify whether the problem is application boot,
   adapter wiring, or server startup
 - configuration precedence is explicit and documented
@@ -64,7 +68,7 @@ The Rack environment translation contract is explicit:
   request headers surfaced as `HTTP_*`
 - `rack.input` is a buffered binary input object populated from supported
   request bodies
-- the current request-body baseline accepts fixed-length bodies and HTTP/1.1
+- the request-body baseline accepts fixed-length bodies and HTTP/1.1
   chunked transfer coding, consumes trailers without surfacing them into the
   Rack env, enforces Vajra's native request-body size limits, and still closes
   the connection after body-bearing requests

--- a/docs/pages/observability.md
+++ b/docs/pages/observability.md
@@ -22,10 +22,9 @@ repository.
 
 The observability surface includes:
 
-- structured logs for boot, shutdown, request lifecycle, and failures
-- metrics for runtime lifecycle, latency, overload, scheduling, and recovery
-- tracing hooks for request execution and runtime state transitions
-- internal events suitable for telemetry pipelines and operator tooling
+- structured logs for boot, worker readiness, shutdown, and failures
+- startup and bind diagnostics
+- request-path visibility through e2e-verifiable HTTP behavior
 
 ## Why These Signals Matter
 
@@ -47,12 +46,12 @@ Good local observability for Vajra means:
 
 ## Integrations
 
-The supported observability integrations are explicit:
+The supported observability contract is log-first:
 
-- OpenTelemetry-style trace integration
-- Prometheus/OpenMetrics-style metrics exposure
-- structured logs suitable for aggregation pipelines
-- runtime events that can feed operator and recovery tooling
+- stdout and stderr carry lifecycle and failure signals
+- startup and shutdown emit explicit lifecycle events
+- load, boot, bind, and request-execution failures stay diagnosable without
+  attaching a debugger
 
 ## Related Reading
 

--- a/docs/pages/operations.md
+++ b/docs/pages/operations.md
@@ -37,24 +37,24 @@ Operators answer:
 - did the native extension load correctly?
 - did the listener bind correctly?
 - did the application boot path complete?
-- are runtime diagnostics consistent with the intended config?
+- are runtime diagnostics consistent with the configured runtime?
 
 ### Steady State
 
 Operators observe:
 
-- request throughput and latency
-- queueing and admission pressure
-- restart and replacement behavior
-- structured runtime events for boot, shutdown, failures, and recovery
+- request success and failure behavior
+- structured runtime events for boot, worker readiness, shutdown, and failures
+- whether the listener is reachable and the application responds correctly
 
 ### Shutdown
 
 Controlled shutdown is explicit:
 
 - stop accepting new work
-- allow in-flight work to finish when policy allows
-- expose escalation boundaries clearly if a forced stop is needed
+- close the request channel to the worker
+- wait for worker exit
+- release the listener cleanly
 
 ## Operating In Degraded States
 

--- a/docs/pages/running-vajra.md
+++ b/docs/pages/running-vajra.md
@@ -18,9 +18,11 @@ Vajra binds to port `3000` and serves a basic serialized HTTP/1.1 response path.
 ## Runtime Expectations
 
 - runs in the foreground
+- starts from the Ruby main thread
 - logs to stdout and stderr
 - exits on interrupt
 - uses the compiled native extension as the runtime entrypoint
+- uses one Ruby worker for application execution
 
 ## Boot Chain
 
@@ -29,8 +31,10 @@ The runtime boot path is direct:
 1. Ruby starts the `exe/vajra` entrypoint.
 2. `require "vajra"` loads the gem and validates the native extension contract.
 3. The package transfers control to `Vajra.start`.
-4. The native runtime opens the listener, accepts connections, and writes the
-   response.
+4. Ruby preload boot runs in the main process.
+5. The main process forks one Ruby worker and waits for worker readiness.
+6. The native runtime opens the listener, accepts connections, and writes the
+   response while the worker executes Rack requests.
 
 That narrow chain matters because build verification, executable smoke tests,
 and runtime troubleshooting all point back to the same load boundary.
@@ -54,8 +58,9 @@ next request and closes the connection when that timeout expires.
 The runtime is designed for direct operation:
 
 - `Ctrl+C` stops the process cleanly
-- the listener stays attached to the foreground process
-- request handling remains in the native runtime, not in a Ruby request loop
+- the listener stays attached to the foreground runtime process
+- request transport remains in the native runtime
+- Rack application execution remains in the Ruby worker
 
 If the executable exits before the startup banner or fails to bind the port,
 use [Troubleshooting](/troubleshooting/) next.

--- a/docs/pages/runtime-model.md
+++ b/docs/pages/runtime-model.md
@@ -6,24 +6,38 @@ permalink: /runtime-model/
 
 # Runtime Model
 
-Vajra starts from the Ruby executable and transfers control to the native
-extension.
+Vajra starts from the Ruby executable, boots the Ruby application, and then
+runs the server through a native runtime plus Ruby worker execution model.
 
 ## Boot Flow
 
 1. Ruby loads the `vajra` package.
 2. The package loads the compiled native extension.
 3. The executable calls `Vajra.start`.
-4. The native runtime opens a listener and handles requests.
+4. Ruby preload boot runs in the main process.
+5. The main process forks one Ruby worker.
+6. The native runtime in the main process opens the listener and handles
+   network I/O after worker readiness succeeds.
+
+## Process Model
+
+Vajra uses an explicit master-and-worker split:
+
+- the main process owns boot orchestration, listener lifecycle, connection
+  acceptance, request parsing, and response transport
+- the Ruby worker owns application request execution
+- the request path between them uses Vajra's request-channel IPC
+- `Vajra.start` must run on the Ruby main thread so that the runtime can fork
+  and supervise the worker safely
 
 ## Listener Model
 
-The listener model is direct:
+The listener model is native-owned:
 
-- one foreground process owns the listener lifecycle
+- one foreground runtime process owns the listener lifecycle
 - the native runtime binds the socket, listens, accepts connections, and writes
-  the response
-- Ruby does not sit in the request path after the handoff into the extension
+  responses
+- Ruby workers do not own client sockets or write directly to the network
 
 ## Connection Lifecycle
 
@@ -32,10 +46,16 @@ For each accepted connection, the runtime:
 1. accepts the client socket
 2. reads request bytes until the header boundary is reached
 3. parses the request line and headers into explicit native request state
-4. rejects malformed request heads with a bounded `400 Bad Request` or `431 Request Header Fields Too Large` response
-5. serializes an explicit HTTP/1.1 response for valid request heads
-6. reuses the connection for the next sequential request when the current exchange is safely message-bounded
-7. closes the client socket when the client asks to close, the exchange is not reusable, or an error path forces termination
+4. streams request-body bytes to the Ruby worker when the request carries a
+   body
+5. rejects malformed request heads with a bounded `400 Bad Request` or
+   `431 Request Header Fields Too Large` response
+6. receives response metadata and response-body segments back from the worker
+7. serializes an explicit HTTP/1.1 response for valid request heads
+8. reuses the connection for the next sequential request when the current
+   exchange is safely message-bounded
+9. closes the client socket when the client asks to close, the exchange is not
+   reusable, or an error path forces termination
 
 That response path keeps the boot contract, smoke tests, and shutdown behavior
 clear and enforceable.
@@ -43,11 +63,11 @@ clear and enforceable.
 ## Shutdown Model
 
 The native runtime installs signal handlers for `SIGINT` and `SIGTERM`. A stop
-request transitions the listener through an explicit draining state before the
-listener is released and the server instance leaves the process.
+request transitions the listener through an explicit draining state, closes the
+request channel, waits for worker exit, and then releases the listener.
 
 ## Runtime Scope
 
 The runtime model centers the listener lifecycle, request handling path,
-shutdown behavior, and the ownership split between Ruby packaging and native
-execution.
+shutdown behavior, and the ownership split between Ruby packaging, native
+transport ownership, and Ruby worker request execution.

--- a/gems/vajra/ext/vajra/rack/rack_request_executor.cpp
+++ b/gems/vajra/ext/vajra/rack/rack_request_executor.cpp
@@ -5,6 +5,7 @@
 
 #include "rack_request_executor.hpp"
 
+#include "ipc/frame_header.hpp"
 #include "request/http_field_utils.hpp"
 #include "request/rack_env.hpp"
 #include "request/request_head_error.hpp"
@@ -12,13 +13,17 @@
 #include "ruby/encoding.h"
 #include "ruby/thread.h"
 
+#include <array>
 #include <atomic>
+#include <cstdint>
 #include <limits>
 #include <memory>
 #include <mutex>
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <sys/socket.h>
+#include <unistd.h>
 #include <utility>
 #include <vector>
 
@@ -43,6 +48,188 @@ namespace
     std::optional<Vajra::response::Response> response;
     std::string error_message;
   };
+
+  enum class RequestBodyEvent : std::uint8_t
+  {
+    chunk = 1,
+    complete = 2,
+    cancel = 3,
+  };
+
+  enum class ResponseMetadataKind : std::uint8_t
+  {
+    no_response = 0,
+    response = 1,
+    head_error = 2,
+    execution_error = 3,
+  };
+
+  enum class ResponseBodyEvent : std::uint8_t
+  {
+    chunk = 1,
+    complete = 2,
+  };
+
+  constexpr std::size_t kInlineBodyChunkBytes =
+      static_cast<std::size_t>(Vajra::ipc::kMaxFramePayloadLength) - 1;
+
+  struct DecodedResponseMetadata
+  {
+    ResponseMetadataKind kind = ResponseMetadataKind::no_response;
+    std::optional<Vajra::response::Response> response;
+    std::string error_message;
+  };
+
+  void write_all_or_throw(int fd, const void *buffer, std::size_t length)
+  {
+    const auto *bytes = static_cast<const std::uint8_t *>(buffer);
+    std::size_t written = 0;
+    while (written < length)
+    {
+      const ssize_t result = write(fd, bytes + written, length - written);
+      if (result < 0)
+      {
+        if (errno == EINTR)
+        {
+          continue;
+        }
+
+        throw std::runtime_error("request channel write failed");
+      }
+
+      written += static_cast<std::size_t>(result);
+    }
+  }
+
+  bool read_exact_or_eof(int fd, void *buffer, std::size_t length)
+  {
+    auto *bytes = static_cast<std::uint8_t *>(buffer);
+    std::size_t read_bytes = 0;
+    while (read_bytes < length)
+    {
+      const ssize_t result = read(fd, bytes + read_bytes, length - read_bytes);
+      if (result == 0)
+      {
+        if (read_bytes == 0)
+        {
+          return false;
+        }
+
+        throw std::runtime_error("request channel closed unexpectedly");
+      }
+
+      if (result < 0)
+      {
+        if (errno == EINTR)
+        {
+          continue;
+        }
+
+        throw std::runtime_error("request channel read failed");
+      }
+
+      read_bytes += static_cast<std::size_t>(result);
+    }
+
+    return true;
+  }
+
+  void append_u32(std::string &buffer, std::uint32_t value)
+  {
+    buffer.push_back(static_cast<char>((value >> 24) & 0xFF));
+    buffer.push_back(static_cast<char>((value >> 16) & 0xFF));
+    buffer.push_back(static_cast<char>((value >> 8) & 0xFF));
+    buffer.push_back(static_cast<char>(value & 0xFF));
+  }
+
+  std::uint32_t read_u32(const std::string &buffer, std::size_t &cursor, const char *error_message)
+  {
+    if (buffer.size() - cursor < 4)
+    {
+      throw std::runtime_error(error_message);
+    }
+
+    const std::uint32_t value =
+        (static_cast<std::uint32_t>(static_cast<unsigned char>(buffer[cursor])) << 24) |
+        (static_cast<std::uint32_t>(static_cast<unsigned char>(buffer[cursor + 1])) << 16) |
+        (static_cast<std::uint32_t>(static_cast<unsigned char>(buffer[cursor + 2])) << 8) |
+        static_cast<std::uint32_t>(static_cast<unsigned char>(buffer[cursor + 3]));
+    cursor += 4;
+    return value;
+  }
+
+  void append_string(std::string &buffer, const std::string &value)
+  {
+    if (value.size() > static_cast<std::size_t>(std::numeric_limits<std::uint32_t>::max()))
+    {
+      throw std::runtime_error("request channel payload string exceeds maximum size");
+    }
+
+    append_u32(buffer, static_cast<std::uint32_t>(value.size()));
+    buffer.append(value);
+  }
+
+  std::string read_string(const std::string &buffer, std::size_t &cursor, const char *error_message)
+  {
+    const std::uint32_t length = read_u32(buffer, cursor, error_message);
+    if (buffer.size() - cursor < length)
+    {
+      throw std::runtime_error(error_message);
+    }
+
+    std::string value = buffer.substr(cursor, length);
+    cursor += length;
+    return value;
+  }
+
+  void write_frame(int fd, Vajra::ipc::FrameFamily family, const std::string &payload)
+  {
+    Vajra::ipc::FrameHeader header{
+        Vajra::ipc::ChannelKind::request,
+        family,
+        Vajra::ipc::kProtocolVersion1_0,
+        static_cast<std::uint32_t>(payload.size())};
+    const std::array<std::uint8_t, Vajra::ipc::kFrameHeaderSize> encoded_header =
+        Vajra::ipc::encode_frame_header(header);
+    write_all_or_throw(fd, encoded_header.data(), encoded_header.size());
+    if (!payload.empty())
+    {
+      write_all_or_throw(fd, payload.data(), payload.size());
+    }
+  }
+
+  bool read_frame(int fd, Vajra::ipc::FrameHeader &header, std::string &payload)
+  {
+    std::array<std::uint8_t, Vajra::ipc::kFrameHeaderSize> encoded_header{};
+    if (!read_exact_or_eof(fd, encoded_header.data(), encoded_header.size()))
+    {
+      return false;
+    }
+
+    Vajra::ipc::HeaderDecodeError error = Vajra::ipc::HeaderDecodeError::none;
+    Vajra::ipc::HeaderDecodeWarning warning = Vajra::ipc::HeaderDecodeWarning::none;
+    const std::optional<Vajra::ipc::FrameHeader> decoded_header =
+        Vajra::ipc::decode_frame_header(encoded_header, error, warning);
+    if (!decoded_header.has_value())
+    {
+      throw std::runtime_error("request channel received an invalid frame header");
+    }
+
+    if (warning != Vajra::ipc::HeaderDecodeWarning::none)
+    {
+      throw std::runtime_error("request channel received an unsupported frame header");
+    }
+
+    payload.assign(decoded_header->payload_length, '\0');
+    if (decoded_header->payload_length > 0 &&
+        !read_exact_or_eof(fd, payload.data(), decoded_header->payload_length))
+    {
+      throw std::runtime_error("request channel closed before payload body");
+    }
+
+    header = *decoded_header;
+    return true;
+  }
 
   std::string exception_message(VALUE exception);
 
@@ -393,6 +580,224 @@ namespace
     return nullptr;
   }
 
+  std::string encode_request_execution_input(const std::vector<Vajra::request::RackEnvEntry> &env_entries)
+  {
+    std::string payload;
+    append_u32(payload, static_cast<std::uint32_t>(env_entries.size()));
+    for (const Vajra::request::RackEnvEntry &entry : env_entries)
+    {
+      append_string(payload, entry.key);
+      append_string(payload, entry.value);
+    }
+
+    return payload;
+  }
+
+  std::vector<Vajra::request::RackEnvEntry> decode_request_execution_input(const std::string &payload)
+  {
+    std::size_t cursor = 0;
+    const std::uint32_t entry_count = read_u32(payload, cursor, "request execution input payload is truncated");
+    std::vector<Vajra::request::RackEnvEntry> env_entries;
+    env_entries.reserve(entry_count);
+    for (std::uint32_t index = 0; index < entry_count; ++index)
+    {
+      env_entries.push_back(Vajra::request::RackEnvEntry{
+          read_string(payload, cursor, "request execution input key is truncated"),
+          read_string(payload, cursor, "request execution input value is truncated")});
+    }
+
+    if (cursor != payload.size())
+    {
+      throw std::runtime_error("request execution input payload contains trailing bytes");
+    }
+
+    return env_entries;
+  }
+
+  std::string encode_request_body_chunk(RequestBodyEvent event, const std::string &chunk)
+  {
+    std::string payload;
+    payload.push_back(static_cast<char>(event));
+    if (event == RequestBodyEvent::chunk)
+    {
+      payload.append(chunk);
+    }
+    return payload;
+  }
+
+  RequestBodyEvent decode_request_body_event(const std::string &payload, std::string &chunk)
+  {
+    if (payload.empty())
+    {
+      throw std::runtime_error("request body continuation payload is empty");
+    }
+
+    const auto event = static_cast<RequestBodyEvent>(static_cast<unsigned char>(payload[0]));
+    switch (event)
+    {
+      case RequestBodyEvent::chunk:
+        chunk.assign(payload.data() + 1, payload.size() - 1);
+        return event;
+      case RequestBodyEvent::complete:
+        chunk.clear();
+        return event;
+      case RequestBodyEvent::cancel:
+        chunk.clear();
+        return event;
+    }
+
+    throw std::runtime_error("request body continuation payload has an unknown event");
+  }
+
+  std::string encode_response_metadata(const std::optional<Vajra::response::Response> &response)
+  {
+    std::string payload;
+    if (!response)
+    {
+      payload.push_back(static_cast<char>(ResponseMetadataKind::no_response));
+      return payload;
+    }
+
+    payload.push_back(static_cast<char>(ResponseMetadataKind::response));
+    append_u32(payload, static_cast<std::uint32_t>(response->status.code));
+    append_string(payload, response->status.reason_phrase);
+    append_u32(payload, static_cast<std::uint32_t>(response->headers.size()));
+    for (const Vajra::response::Header &header : response->headers)
+    {
+      append_string(payload, header.name);
+      append_string(payload, header.value);
+    }
+    return payload;
+  }
+
+  std::string encode_response_error(ResponseMetadataKind kind, const std::string &message)
+  {
+    std::string payload;
+    payload.push_back(static_cast<char>(kind));
+    append_string(payload, message);
+    return payload;
+  }
+
+  DecodedResponseMetadata decode_response_metadata(const std::string &payload)
+  {
+    if (payload.empty())
+    {
+      throw std::runtime_error("response metadata payload is empty");
+    }
+
+    std::size_t cursor = 1;
+    const auto kind = static_cast<ResponseMetadataKind>(static_cast<unsigned char>(payload[0]));
+    switch (kind)
+    {
+      case ResponseMetadataKind::no_response:
+        if (cursor != payload.size())
+        {
+          throw std::runtime_error("no-response metadata payload contains trailing bytes");
+        }
+        return DecodedResponseMetadata{kind, std::nullopt, ""};
+      case ResponseMetadataKind::response:
+      {
+        const int status_code = static_cast<int>(read_u32(payload, cursor, "response metadata status is truncated"));
+        const std::string reason_phrase = read_string(payload, cursor, "response metadata reason phrase is truncated");
+        const std::uint32_t header_count = read_u32(payload, cursor, "response metadata header count is truncated");
+        std::vector<Vajra::response::Header> headers;
+        headers.reserve(header_count);
+        for (std::uint32_t index = 0; index < header_count; ++index)
+        {
+          headers.push_back(Vajra::response::Header{
+              read_string(payload, cursor, "response header name is truncated"),
+              read_string(payload, cursor, "response header value is truncated")});
+        }
+
+        if (cursor != payload.size())
+        {
+          throw std::runtime_error("response metadata payload contains trailing bytes");
+        }
+
+        return DecodedResponseMetadata{
+            kind,
+            Vajra::response::Response{
+                Vajra::response::Status{status_code, reason_phrase},
+                std::move(headers),
+                "",
+                Vajra::response::ConnectionBehavior::close},
+            ""};
+      }
+      case ResponseMetadataKind::head_error:
+      case ResponseMetadataKind::execution_error:
+      {
+        const std::string error_message = read_string(payload, cursor, "response error payload is truncated");
+        if (cursor != payload.size())
+        {
+          throw std::runtime_error("response error payload contains trailing bytes");
+        }
+
+        return DecodedResponseMetadata{kind, std::nullopt, error_message};
+      }
+    }
+
+    throw std::runtime_error("response metadata payload has an unknown kind");
+  }
+
+  std::string encode_response_body_event(ResponseBodyEvent event, const std::string &chunk)
+  {
+    std::string payload;
+    payload.push_back(static_cast<char>(event));
+    if (event == ResponseBodyEvent::chunk)
+    {
+      payload.append(chunk);
+    }
+    return payload;
+  }
+
+  ResponseBodyEvent decode_response_body_event(const std::string &payload, std::string &chunk)
+  {
+    if (payload.empty())
+    {
+      throw std::runtime_error("response body continuation payload is empty");
+    }
+
+    const auto event = static_cast<ResponseBodyEvent>(static_cast<unsigned char>(payload[0]));
+    switch (event)
+    {
+      case ResponseBodyEvent::chunk:
+        chunk.assign(payload.data() + 1, payload.size() - 1);
+        return event;
+      case ResponseBodyEvent::complete:
+        chunk.clear();
+        return event;
+    }
+
+    throw std::runtime_error("response body continuation payload has an unknown event");
+  }
+
+  class BufferedRackExecutionSession final : public Vajra::rack::RackExecutionSession
+  {
+  public:
+    BufferedRackExecutionSession(
+        const Vajra::rack::RackExecutionTransport &transport,
+        std::vector<Vajra::request::RackEnvEntry> env_entries)
+        : transport_(transport),
+          env_entries_(std::move(env_entries))
+    {
+    }
+
+    void append_request_body_chunk(const std::string &chunk) override
+    {
+      request_body_.append(chunk);
+    }
+
+    std::optional<Vajra::response::Response> finish() override
+    {
+      return transport_.execute(env_entries_, request_body_);
+    }
+
+  private:
+    const Vajra::rack::RackExecutionTransport &transport_;
+    std::vector<Vajra::request::RackEnvEntry> env_entries_;
+    std::string request_body_;
+  };
+
   class SameProcessRackExecutionTransport final : public Vajra::rack::RackExecutionTransport
   {
   public:
@@ -416,6 +821,186 @@ namespace
       return context.response;
     }
   };
+
+  class CurrentThreadRackExecutionTransport final : public Vajra::rack::RackExecutionTransport
+  {
+  public:
+    std::optional<Vajra::response::Response> execute(
+        const std::vector<Vajra::request::RackEnvEntry> &env_entries,
+        const std::string &request_body) const override
+    {
+      if (!rack_execution_callback_installed_flag.load(std::memory_order_acquire))
+      {
+        return std::nullopt;
+      }
+
+      ExecutionCallContext context{&env_entries, &request_body, std::nullopt, ""};
+      execute_rack_request_with_gvl(&context);
+
+      if (!context.error_message.empty())
+      {
+        throw std::runtime_error("Rack request execution failed: " + context.error_message);
+      }
+
+      return context.response;
+    }
+  };
+
+  class WorkerProcessRackExecutionSession final : public Vajra::rack::RackExecutionSession
+  {
+  public:
+    WorkerProcessRackExecutionSession(int channel_fd, std::mutex &channel_mutex)
+        : channel_fd_(channel_fd),
+          channel_lock_(channel_mutex)
+    {
+    }
+
+    ~WorkerProcessRackExecutionSession() override
+    {
+      if (!finished_)
+      {
+        try
+        {
+          write_frame(
+              channel_fd_,
+              Vajra::ipc::FrameFamily::request_body_continuation,
+              encode_request_body_chunk(RequestBodyEvent::cancel, ""));
+        }
+        catch (...)
+        {
+        }
+      }
+    }
+
+    void send_request_start(const std::vector<Vajra::request::RackEnvEntry> &env_entries)
+    {
+      write_frame(channel_fd_, Vajra::ipc::FrameFamily::request_execution_input, encode_request_execution_input(env_entries));
+    }
+
+    void append_request_body_chunk(const std::string &chunk) override
+    {
+      std::size_t cursor = 0;
+      while (cursor < chunk.size())
+      {
+        const std::size_t length = std::min(kInlineBodyChunkBytes, chunk.size() - cursor);
+        write_frame(
+            channel_fd_,
+            Vajra::ipc::FrameFamily::request_body_continuation,
+            encode_request_body_chunk(RequestBodyEvent::chunk, chunk.substr(cursor, length)));
+        cursor += length;
+      }
+    }
+
+    std::optional<Vajra::response::Response> finish() override
+    {
+      write_frame(
+          channel_fd_,
+          Vajra::ipc::FrameFamily::request_body_continuation,
+          encode_request_body_chunk(RequestBodyEvent::complete, ""));
+      finished_ = true;
+
+      Vajra::ipc::FrameHeader header{};
+      std::string payload;
+      if (!read_frame(channel_fd_, header, payload))
+      {
+        throw std::runtime_error("worker request channel closed before response metadata");
+      }
+      if (header.family != Vajra::ipc::FrameFamily::response_metadata_result)
+      {
+        throw std::runtime_error("worker request channel returned an unexpected response frame");
+      }
+
+      DecodedResponseMetadata metadata = decode_response_metadata(payload);
+      switch (metadata.kind)
+      {
+        case ResponseMetadataKind::no_response:
+          return std::nullopt;
+        case ResponseMetadataKind::head_error:
+          throw Vajra::request::bad_request_error(metadata.error_message);
+        case ResponseMetadataKind::execution_error:
+          throw std::runtime_error(metadata.error_message);
+        case ResponseMetadataKind::response:
+          break;
+      }
+
+      std::optional<Vajra::response::Response> response = std::move(metadata.response);
+      for (;;)
+      {
+        if (!read_frame(channel_fd_, header, payload))
+        {
+          throw std::runtime_error("worker request channel closed before response body completion");
+        }
+        if (header.family != Vajra::ipc::FrameFamily::response_body_continuation)
+        {
+          throw std::runtime_error("worker request channel returned an unexpected response body frame");
+        }
+
+        std::string chunk;
+        const ResponseBodyEvent event = decode_response_body_event(payload, chunk);
+        if (event == ResponseBodyEvent::complete)
+        {
+          return response;
+        }
+
+        response->body.append(chunk);
+      }
+    }
+
+  private:
+    int channel_fd_;
+    std::unique_lock<std::mutex> channel_lock_;
+    bool finished_ = false;
+  };
+
+  class WorkerProcessRackExecutionTransport final : public Vajra::rack::RackExecutionTransport
+  {
+  public:
+    explicit WorkerProcessRackExecutionTransport(int channel_fd)
+        : channel_fd_(channel_fd)
+    {
+    }
+
+    std::unique_ptr<Vajra::rack::RackExecutionSession> start(
+        const std::vector<Vajra::request::RackEnvEntry> &env_entries) const override
+    {
+      auto session = std::make_unique<WorkerProcessRackExecutionSession>(channel_fd_, channel_mutex_);
+      session->send_request_start(env_entries);
+      return session;
+    }
+
+    std::optional<Vajra::response::Response> execute(
+        const std::vector<Vajra::request::RackEnvEntry> &,
+        const std::string &) const override
+    {
+      throw std::logic_error("worker request transport must use streaming start()");
+    }
+
+  private:
+    int channel_fd_;
+    mutable std::mutex channel_mutex_;
+  };
+
+  class RequestExecutionBridgeSession final : public Vajra::request::RequestExecutionSession
+  {
+  public:
+    explicit RequestExecutionBridgeSession(std::unique_ptr<Vajra::rack::RackExecutionSession> session)
+        : session_(std::move(session))
+    {
+    }
+
+    void append_request_body_chunk(const std::string &chunk) override
+    {
+      session_->append_request_body_chunk(chunk);
+    }
+
+    std::optional<Vajra::response::Response> finish() override
+    {
+      return session_->finish();
+    }
+
+  private:
+    std::unique_ptr<Vajra::rack::RackExecutionSession> session_;
+  };
 }
 
 void Vajra::rack::initialize_rack_execution_bridge()
@@ -433,6 +1018,17 @@ void Vajra::rack::set_rack_execution_callback(VALUE callback)
   rack_execution_callback_installed_flag.store(!NIL_P(callback), std::memory_order_release);
 }
 
+std::shared_ptr<const Vajra::rack::RackExecutionTransport> Vajra::rack::request_channel_transport(int channel_fd)
+{
+  return std::make_shared<WorkerProcessRackExecutionTransport>(channel_fd);
+}
+
+std::unique_ptr<Vajra::rack::RackExecutionSession> Vajra::rack::RackExecutionTransport::start(
+    const std::vector<request::RackEnvEntry> &env_entries) const
+{
+  return std::make_unique<BufferedRackExecutionSession>(*this, env_entries);
+}
+
 Vajra::rack::RackRequestExecutor::RackRequestExecutor()
     : transport_(std::make_shared<SameProcessRackExecutionTransport>())
 {
@@ -448,10 +1044,116 @@ Vajra::rack::RackRequestExecutor::RackRequestExecutor(
   }
 }
 
+std::unique_ptr<Vajra::request::RequestExecutionSession> Vajra::rack::RackRequestExecutor::start(
+    const request::RequestContext &request_context) const
+{
+  request::RackEnvBuilder builder;
+  const std::vector<request::RackEnvEntry> env_entries = builder.build(request_context);
+  return std::make_unique<RequestExecutionBridgeSession>(transport_->start(env_entries));
+}
+
 std::optional<Vajra::response::Response> Vajra::rack::RackRequestExecutor::execute(
     const request::RequestContext &request_context) const
 {
   request::RackEnvBuilder builder;
   const std::vector<request::RackEnvEntry> env_entries = builder.build(request_context);
   return transport_->execute(env_entries, request_context.request_body);
+}
+
+void Vajra::rack::run_worker_request_execution_loop(int channel_fd)
+{
+  CurrentThreadRackExecutionTransport transport;
+
+  for (;;)
+  {
+    Vajra::ipc::FrameHeader header{};
+    std::string payload;
+    if (!read_frame(channel_fd, header, payload))
+    {
+      return;
+    }
+
+    if (header.family != Vajra::ipc::FrameFamily::request_execution_input)
+    {
+      throw std::runtime_error("worker request loop expected request execution input");
+    }
+
+    std::vector<request::RackEnvEntry> env_entries = decode_request_execution_input(payload);
+    std::string request_body;
+    bool request_canceled = false;
+
+    for (;;)
+    {
+      if (!read_frame(channel_fd, header, payload))
+      {
+        throw std::runtime_error("worker request loop closed before request body completion");
+      }
+
+      if (header.family != Vajra::ipc::FrameFamily::request_body_continuation)
+      {
+        throw std::runtime_error("worker request loop expected request body continuation");
+      }
+
+      std::string chunk;
+      const RequestBodyEvent event = decode_request_body_event(payload, chunk);
+      if (event == RequestBodyEvent::cancel)
+      {
+        request_canceled = true;
+        break;
+      }
+      if (event == RequestBodyEvent::complete)
+      {
+        break;
+      }
+
+      request_body.append(chunk);
+    }
+
+    if (request_canceled)
+    {
+      continue;
+    }
+
+    try
+    {
+      const std::optional<Vajra::response::Response> response = transport.execute(env_entries, request_body);
+      write_frame(
+          channel_fd,
+          Vajra::ipc::FrameFamily::response_metadata_result,
+          encode_response_metadata(response));
+      if (!response)
+      {
+        continue;
+      }
+
+      std::size_t cursor = 0;
+      while (cursor < response->body.size())
+      {
+        const std::size_t length = std::min(kInlineBodyChunkBytes, response->body.size() - cursor);
+        write_frame(
+            channel_fd,
+            Vajra::ipc::FrameFamily::response_body_continuation,
+            encode_response_body_event(ResponseBodyEvent::chunk, response->body.substr(cursor, length)));
+        cursor += length;
+      }
+      write_frame(
+          channel_fd,
+          Vajra::ipc::FrameFamily::response_body_continuation,
+          encode_response_body_event(ResponseBodyEvent::complete, ""));
+    }
+    catch (const Vajra::request::HeadError &error)
+    {
+      write_frame(
+          channel_fd,
+          Vajra::ipc::FrameFamily::response_metadata_result,
+          encode_response_error(ResponseMetadataKind::head_error, error.what()));
+    }
+    catch (const std::exception &error)
+    {
+      write_frame(
+          channel_fd,
+          Vajra::ipc::FrameFamily::response_metadata_result,
+          encode_response_error(ResponseMetadataKind::execution_error, error.what()));
+    }
+  }
 }

--- a/gems/vajra/ext/vajra/rack/rack_request_executor.hpp
+++ b/gems/vajra/ext/vajra/rack/rack_request_executor.hpp
@@ -11,6 +11,7 @@
 #include "ruby.h"
 
 #include <memory>
+#include <optional>
 #include <vector>
 
 namespace Vajra
@@ -19,11 +20,23 @@ namespace Vajra
   {
     void initialize_rack_execution_bridge();
     void set_rack_execution_callback(VALUE callback);
+    void run_worker_request_execution_loop(int channel_fd);
+    std::shared_ptr<const class RackExecutionTransport> request_channel_transport(int channel_fd);
+
+    class RackExecutionSession
+    {
+    public:
+      virtual ~RackExecutionSession() = default;
+      virtual void append_request_body_chunk(const std::string &chunk) = 0;
+      virtual std::optional<Vajra::response::Response> finish() = 0;
+    };
 
     class RackExecutionTransport
     {
     public:
       virtual ~RackExecutionTransport() = default;
+      virtual std::unique_ptr<RackExecutionSession> start(
+          const std::vector<request::RackEnvEntry> &env_entries) const;
       virtual std::optional<Vajra::response::Response> execute(
           const std::vector<request::RackEnvEntry> &env_entries,
           const std::string &request_body) const = 0;
@@ -35,6 +48,8 @@ namespace Vajra
       RackRequestExecutor();
       explicit RackRequestExecutor(std::shared_ptr<const RackExecutionTransport> transport);
 
+      std::unique_ptr<request::RequestExecutionSession> start(
+          const request::RequestContext &request_context) const override;
       std::optional<Vajra::response::Response> execute(const request::RequestContext &request_context) const override;
 
     private:

--- a/gems/vajra/ext/vajra/request/request_body_reader.cpp
+++ b/gems/vajra/ext/vajra/request/request_body_reader.cpp
@@ -10,6 +10,7 @@
 
 #include <cerrno>
 #include <cstdlib>
+#include <functional>
 #include <limits>
 #include <string>
 #include <sys/socket.h>
@@ -345,11 +346,25 @@ namespace
     }
   }
 
+  void emit_body_chunk(
+      const std::function<void(const std::string &chunk)> &on_body_chunk,
+      const char *data,
+      std::size_t length)
+  {
+    if (length == 0)
+    {
+      return;
+    }
+
+    on_body_chunk(std::string(data, length));
+  }
+
   Vajra::request::BodyReadResult read_content_length_body(
       int client_fd,
       std::size_t content_length,
       std::string buffered_bytes,
-      std::size_t max_request_body_bytes)
+      std::size_t max_request_body_bytes,
+      const std::function<void(const std::string &chunk)> &on_body_chunk)
   {
     if (content_length > max_request_body_bytes)
     {
@@ -358,9 +373,8 @@ namespace
 
     const std::size_t body_start = 0;
     ensure_buffer_bytes(buffered_bytes, body_start, content_length, client_fd);
-    return Vajra::request::BodyReadResult{
-        buffered_bytes.substr(body_start, content_length),
-        buffered_bytes.substr(body_start + content_length)};
+    emit_body_chunk(on_body_chunk, buffered_bytes.data() + body_start, content_length);
+    return Vajra::request::BodyReadResult{"", buffered_bytes.substr(body_start + content_length)};
   }
 
   Vajra::request::BodyReadResult read_chunked_body(
@@ -368,10 +382,11 @@ namespace
       std::string buffered_bytes,
       std::size_t max_request_body_bytes,
       std::size_t max_chunk_line_bytes,
-      std::size_t max_trailer_line_bytes)
+      std::size_t max_trailer_line_bytes,
+      const std::function<void(const std::string &chunk)> &on_body_chunk)
   {
-    std::string body;
     std::size_t cursor = 0;
+    std::size_t total_body_bytes = 0;
 
     while (true)
     {
@@ -380,17 +395,18 @@ namespace
       if (chunk_size == 0)
       {
         consume_trailers(buffered_bytes, cursor, client_fd, max_trailer_line_bytes);
-        return Vajra::request::BodyReadResult{body, unread_suffix(buffered_bytes, cursor)};
+        return Vajra::request::BodyReadResult{"", unread_suffix(buffered_bytes, cursor)};
       }
 
-      if (chunk_size > max_request_body_bytes - body.size())
+      if (chunk_size > max_request_body_bytes - total_body_bytes)
       {
         raise_request_body_too_large();
       }
 
       ensure_buffer_bytes(buffered_bytes, cursor, chunk_size + 2, client_fd);
-      body.append(buffered_bytes.data() + cursor, chunk_size);
+      emit_body_chunk(on_body_chunk, buffered_bytes.data() + cursor, chunk_size);
       cursor += chunk_size;
+      total_body_bytes += chunk_size;
       if (buffered_bytes[cursor] != '\r' || buffered_bytes[cursor + 1] != '\n')
       {
         raise_invalid_body_read();
@@ -402,9 +418,10 @@ namespace
   }
 }
 
-Vajra::request::BodyReadResult Vajra::request::RequestBodyReader::read(
+Vajra::request::BodyReadResult Vajra::request::RequestBodyReader::stream_read(
     int client_fd,
     const ParsedRequest &request,
+    const std::function<void(const std::string &chunk)> &on_body_chunk,
     std::string buffered_bytes) const
 {
   const BodyReadPlan plan = body_read_plan_for(request);
@@ -418,15 +435,34 @@ Vajra::request::BodyReadResult Vajra::request::RequestBodyReader::read(
         client_fd,
         plan.content_length,
         std::move(buffered_bytes),
-        max_request_body_bytes_);
+        max_request_body_bytes_,
+        on_body_chunk);
   case BodyFraming::chunked:
     return read_chunked_body(
         client_fd,
         std::move(buffered_bytes),
         max_request_body_bytes_,
         max_chunk_line_bytes_,
-        max_trailer_line_bytes_);
+        max_trailer_line_bytes_,
+        on_body_chunk);
   }
 
   raise_invalid_body_read();
+}
+
+Vajra::request::BodyReadResult Vajra::request::RequestBodyReader::read(
+    int client_fd,
+    const ParsedRequest &request,
+    std::string buffered_bytes) const
+{
+  std::string body;
+  BodyReadResult result = stream_read(
+      client_fd,
+      request,
+      [&body](const std::string &chunk) {
+        body.append(chunk);
+      },
+      std::move(buffered_bytes));
+  result.body = std::move(body);
+  return result;
 }

--- a/gems/vajra/ext/vajra/request/request_body_reader.hpp
+++ b/gems/vajra/ext/vajra/request/request_body_reader.hpp
@@ -9,6 +9,7 @@
 #include "request_head_types.hpp"
 
 #include <cstddef>
+#include <functional>
 #include <stdexcept>
 #include <string>
 
@@ -46,6 +47,12 @@ namespace Vajra
             max_trailer_line_bytes_(max_trailer_line_bytes)
       {
       }
+
+      BodyReadResult stream_read(
+          int client_fd,
+          const ParsedRequest &request,
+          const std::function<void(const std::string &chunk)> &on_body_chunk,
+          std::string buffered_bytes = "") const;
 
       BodyReadResult read(
           int client_fd,

--- a/gems/vajra/ext/vajra/request/request_executor.cpp
+++ b/gems/vajra/ext/vajra/request/request_executor.cpp
@@ -1,0 +1,50 @@
+// Copyright Codevedas Inc. 2025-present
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "request_executor.hpp"
+
+#include <memory>
+#include <stdexcept>
+
+namespace
+{
+  class BufferedRequestExecutionSession final : public Vajra::request::RequestExecutionSession
+  {
+  public:
+    BufferedRequestExecutionSession(
+        const Vajra::request::RequestExecutor &request_executor,
+        Vajra::request::RequestContext request_context)
+        : request_executor_(request_executor),
+          request_context_(std::move(request_context))
+    {
+    }
+
+    void append_request_body_chunk(const std::string &chunk) override
+    {
+      request_context_.request_body.append(chunk);
+    }
+
+    std::optional<Vajra::response::Response> finish() override
+    {
+      return request_executor_.execute(request_context_);
+    }
+
+  private:
+    const Vajra::request::RequestExecutor &request_executor_;
+    Vajra::request::RequestContext request_context_;
+  };
+}
+
+std::unique_ptr<Vajra::request::RequestExecutionSession> Vajra::request::RequestExecutor::start(
+    const RequestContext &request_context) const
+{
+  return std::make_unique<BufferedRequestExecutionSession>(*this, request_context);
+}
+
+std::optional<Vajra::response::Response> Vajra::request::RequestExecutor::execute(
+    const RequestContext &) const
+{
+  throw std::logic_error("request executor must override execute() or start()");
+}

--- a/gems/vajra/ext/vajra/request/request_executor.hpp
+++ b/gems/vajra/ext/vajra/request/request_executor.hpp
@@ -9,17 +9,27 @@
 #include "request_context.hpp"
 #include "response/response.hpp"
 
+#include <memory>
 #include <optional>
 
 namespace Vajra
 {
   namespace request
   {
+    class RequestExecutionSession
+    {
+    public:
+      virtual ~RequestExecutionSession() = default;
+      virtual void append_request_body_chunk(const std::string &chunk) = 0;
+      virtual std::optional<Vajra::response::Response> finish() = 0;
+    };
+
     class RequestExecutor
     {
     public:
       virtual ~RequestExecutor() = default;
-      virtual std::optional<Vajra::response::Response> execute(const RequestContext &request_context) const = 0;
+      virtual std::unique_ptr<RequestExecutionSession> start(const RequestContext &request_context) const;
+      virtual std::optional<Vajra::response::Response> execute(const RequestContext &request_context) const;
     };
   }
 }

--- a/gems/vajra/ext/vajra/request/request_processor.cpp
+++ b/gems/vajra/ext/vajra/request/request_processor.cpp
@@ -137,29 +137,47 @@ void Vajra::request::RequestProcessor::handle(int client_fd, const SocketContext
       return;
     }
 
+    const Vajra::response::ConnectionBehavior connection_behavior = connection_behavior_for(request_context.request);
+    Vajra::response::Response response;
     try
     {
-      BodyReadResult body_read_result =
-          request_body_reader_.read(client_fd, request_context.request, std::move(buffered_bytes));
-      request_context.request_body = std::move(body_read_result.body);
+      std::unique_ptr<RequestExecutionSession> execution_session;
+      if (request_executor_)
+      {
+        execution_session = request_executor_->start(request_context);
+      }
+      else
+      {
+        execution_session = nullptr;
+      }
+
+      BodyReadResult body_read_result = request_body_reader_.stream_read(
+          client_fd,
+          request_context.request,
+          [&request_context, &execution_session](const std::string &chunk) {
+            if (execution_session)
+            {
+              execution_session->append_request_body_chunk(chunk);
+              return;
+            }
+
+            request_context.request_body.append(chunk);
+          },
+          std::move(buffered_bytes));
       buffered_bytes = std::move(body_read_result.remaining_buffered_bytes);
+
+      if (execution_session)
+      {
+        response = response_for(*execution_session, connection_behavior);
+      }
+      else
+      {
+        response = response_for(request_context, connection_behavior);
+      }
     }
     catch (const BodyReadIncompleteError &)
     {
       return;
-    }
-    catch (const HeadError &error)
-    {
-      reject_request_head(client_fd, error);
-      return;
-    }
-
-    const Vajra::response::ConnectionBehavior connection_behavior = connection_behavior_for(request_context.request);
-
-    Vajra::response::Response response;
-    try
-    {
-      response = response_for(request_context, connection_behavior);
     }
     catch (const HeadError &error)
     {
@@ -182,6 +200,23 @@ void Vajra::request::RequestProcessor::handle(int client_fd, const SocketContext
       return;
     }
   }
+}
+
+Vajra::response::Response Vajra::request::RequestProcessor::response_for(
+    RequestExecutionSession &execution_session,
+    Vajra::response::ConnectionBehavior connection_behavior) const
+{
+  std::optional<Vajra::response::Response> response = execution_session.finish();
+  if (!response)
+  {
+    return response_writer_.success_response(connection_behavior);
+  }
+
+  response->headers = Vajra::response::strip_framing_headers(response->headers);
+  response->connection_behavior = connection_behavior;
+  Vajra::response::ResponseSerializer serializer;
+  serializer.validate(*response);
+  return *response;
 }
 
 Vajra::response::Response Vajra::request::RequestProcessor::response_for(

--- a/gems/vajra/ext/vajra/request/request_processor.hpp
+++ b/gems/vajra/ext/vajra/request/request_processor.hpp
@@ -33,6 +33,9 @@ namespace Vajra
     private:
       Vajra::response::ConnectionBehavior connection_behavior_for(const ParsedRequest &request) const;
       Vajra::response::Response response_for(
+          RequestExecutionSession &execution_session,
+          Vajra::response::ConnectionBehavior connection_behavior) const;
+      Vajra::response::Response response_for(
           const RequestContext &request_context,
           Vajra::response::ConnectionBehavior connection_behavior) const;
       void reject_request_head(int client_fd, const HeadError &error) const;

--- a/gems/vajra/ext/vajra/vajra.cpp
+++ b/gems/vajra/ext/vajra/vajra.cpp
@@ -13,16 +13,20 @@
 #include <signal.h>
 #include <cstdlib>
 #include <cerrno>
+#include <chrono>
 #include <exception>
+#include <iomanip>
 #include <iostream>
 #include <memory>
 #include <mutex>
 #include <limits>
 #include <optional>
+#include <sstream>
 #include <stdexcept>
 #include <cstring>
 #include <cstdint>
 #include <string>
+#include <sys/socket.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -32,6 +36,7 @@ namespace
   std::mutex server_mutex;
   std::unique_ptr<Vajra::Server> server_instance;
   pid_t worker_pid = -1;
+  int worker_request_channel_fd = -1;
   bool stop_requested = false;
   bool worker_startup_in_progress = false;
   ID id_port;
@@ -40,10 +45,9 @@ namespace
   std::mutex boot_callback_mutex;
   VALUE boot_callback = Qnil;
   constexpr const char *kMasterPreloadRuntimeRole = "ruby_master_preload";
+  constexpr const char *kMasterControlRuntimeRole = "ruby_master_control";
   constexpr const char *kWorkerBootstrapRuntimeRole = "ruby_worker_bootstrap";
   constexpr const char *kMasterWorkerMode = "master_worker";
-  constexpr const char *kSingleProcessRuntimeRole = "single_process_bootstrap";
-  constexpr const char *kSingleProcessMode = "single_process";
   constexpr int kWorkerProcessCount = 1;
   constexpr std::size_t kMaxWorkerBootstrapStringPayloadBytes = 64 * 1024;
 
@@ -129,6 +133,18 @@ namespace
     {
       shutting_down = 1;
     }
+  }
+
+  std::string utc_timestamp()
+  {
+    const auto now = std::chrono::system_clock::now();
+    const std::time_t now_time = std::chrono::system_clock::to_time_t(now);
+    std::tm utc_time{};
+    gmtime_r(&now_time, &utc_time);
+
+    std::ostringstream timestamp;
+    timestamp << std::put_time(&utc_time, "%Y-%m-%dT%H:%M:%SZ");
+    return timestamp.str();
   }
 
   class SignalHandlerGuard
@@ -800,29 +816,34 @@ namespace VajraNative
       }
     }
 
-    void set_worker_pid(pid_t pid)
+    void set_worker_runtime(pid_t pid, int request_channel_fd)
     {
       const std::lock_guard<std::mutex> lock(server_mutex);
       worker_pid = pid;
+      worker_request_channel_fd = request_channel_fd;
       worker_startup_in_progress = false;
     }
 
     void clear_worker_pid()
     {
+      int request_channel_fd = -1;
       const std::lock_guard<std::mutex> lock(server_mutex);
+      request_channel_fd = worker_request_channel_fd;
       worker_pid = -1;
+      worker_request_channel_fd = -1;
       stop_requested = false;
       worker_startup_in_progress = false;
+      close_fd_if_open(request_channel_fd);
     }
 
-    void install_single_process_server(std::unique_ptr<Vajra::Server> server)
+    void install_server_instance(std::unique_ptr<Vajra::Server> server)
     {
       const std::lock_guard<std::mutex> lock(server_mutex);
       server_instance = std::move(server);
       worker_startup_in_progress = false;
     }
 
-    std::unique_ptr<Vajra::Server> take_single_process_server()
+    std::unique_ptr<Vajra::Server> take_server_instance()
     {
       const std::lock_guard<std::mutex> lock(server_mutex);
       return std::move(server_instance);
@@ -844,18 +865,39 @@ namespace VajraNative
     {
       pid_t pid = -1;
       bool startup_in_progress = false;
+      int request_channel_fd = -1;
       {
         const std::lock_guard<std::mutex> lock(server_mutex);
         pid = worker_pid;
+        request_channel_fd = worker_request_channel_fd;
         startup_in_progress = worker_startup_in_progress;
         if (pid > 0 || startup_in_progress)
         {
           stop_requested = true;
         }
       }
+
+      if (request_channel_fd >= 0)
+      {
+        shutdown(request_channel_fd, SHUT_RDWR);
+        close_fd_if_open(request_channel_fd);
+        {
+          const std::lock_guard<std::mutex> lock(server_mutex);
+          if (worker_request_channel_fd == request_channel_fd)
+          {
+            worker_request_channel_fd = -1;
+          }
+        }
+      }
+
       if (pid <= 0)
       {
-        return false;
+        return startup_in_progress;
+      }
+
+      if (request_channel_fd >= 0)
+      {
+        return true;
       }
 
       for (;;)
@@ -971,7 +1013,7 @@ namespace VajraNative
     }
 
     void run_worker_process(
-        int listener_fd,
+        int request_channel_fd,
         int port,
         std::size_t max_request_head_bytes,
         int readiness_write_fd)
@@ -989,26 +1031,16 @@ namespace VajraNative
         }
 
         report_worker_boot_ready(readiness_write_fd);
+        std::cout << "[Vajra][lifecycle] " << utc_timestamp()
+                  << " event=worker_ready state=booting boot_status=ready stop_reason=none"
+                  << " port=" << port
+                  << " listener_owned=false listener_fd=-1"
+                  << " mode=" << kMasterWorkerMode
+                  << " runtime_role=" << boot_result.runtime_role
+                  << " worker_processes=" << kWorkerProcessCount
+                  << std::endl;
         close(readiness_write_fd);
-
-        Vajra::Server server(
-            port,
-            max_request_head_bytes,
-            std::make_shared<Vajra::rack::RackRequestExecutor>(),
-            boot_result.runtime_role,
-            kMasterWorkerMode,
-            kWorkerProcessCount,
-            listener_fd);
-        ServerRunContext context{&server, ""};
-        rb_thread_call_without_gvl(
-            run_server_without_gvl,
-            &context,
-            RUBY_UBF_IO,
-            nullptr);
-        if (!context.error_message.empty())
-        {
-          throw std::runtime_error(context.error_message);
-        }
+        Vajra::rack::run_worker_request_execution_loop(request_channel_fd);
         _exit(0);
       }
       catch (const std::exception &error)
@@ -1023,21 +1055,17 @@ namespace VajraNative
       }
     }
 
-    void run_single_process_server(int port, std::size_t max_request_head_bytes)
+    void run_master_runtime_server(int port, std::size_t max_request_head_bytes, int request_channel_fd)
     {
-      const BootContractResult boot_result = run_boot_contract(
-          BootContractConfig{port, max_request_head_bytes, kSingleProcessRuntimeRole});
-      ensure_ready_boot_result(boot_result);
-
       auto server = std::make_unique<Vajra::Server>(
           port,
           max_request_head_bytes,
-          std::make_shared<Vajra::rack::RackRequestExecutor>(),
-          boot_result.runtime_role,
-          kSingleProcessMode,
-          0);
+          std::make_shared<Vajra::rack::RackRequestExecutor>(Vajra::rack::request_channel_transport(request_channel_fd)),
+          kMasterControlRuntimeRole,
+          kMasterWorkerMode,
+          kWorkerProcessCount);
       Vajra::Server *server_ptr = server.get();
-      install_single_process_server(std::move(server));
+      install_server_instance(std::move(server));
       ServerRunContext context{server_ptr, ""};
 
       try
@@ -1054,7 +1082,7 @@ namespace VajraNative
       }
       catch (...)
       {
-        auto owned_server = take_single_process_server();
+        auto owned_server = take_server_instance();
         if (owned_server)
         {
           owned_server->stop();
@@ -1062,7 +1090,7 @@ namespace VajraNative
         throw;
       }
 
-      auto owned_server = take_single_process_server();
+      auto owned_server = take_server_instance();
       if (owned_server)
       {
         owned_server->stop();
@@ -1092,23 +1120,28 @@ namespace VajraNative
 
       if (!start_called_from_ruby_main_thread())
       {
-        run_single_process_server(port, max_request_head_bytes);
-        return;
+        throw std::runtime_error("worker-only Vajra.start must be invoked from the Ruby main thread");
       }
       const BootContractResult master_boot_result = run_boot_contract(
           BootContractConfig{port, max_request_head_bytes, kMasterPreloadRuntimeRole});
       ensure_ready_boot_result(master_boot_result);
 
-      Vajra::listener::Socket listener_socket;
-      Vajra::listener::SocketBinding binding = listener_socket.open(port);
-
       int readiness_pipe[2] = {-1, -1};
       if (pipe(readiness_pipe) != 0)
       {
         const int error_number = errno;
-        close_fd_if_open(binding.fd);
         throw std::runtime_error(
             std::string("worker bootstrap pipe creation failed: ") + std::strerror(error_number));
+      }
+
+      int request_channel[2] = {-1, -1};
+      if (socketpair(AF_UNIX, SOCK_STREAM, 0, request_channel) != 0)
+      {
+        const int error_number = errno;
+        close_fd_if_open(readiness_pipe[0]);
+        close_fd_if_open(readiness_pipe[1]);
+        throw std::runtime_error(
+            std::string("worker request channel creation failed: ") + std::strerror(error_number));
       }
 
 #if defined(__APPLE__)
@@ -1124,18 +1157,22 @@ namespace VajraNative
         const int error_number = errno;
         close_fd_if_open(readiness_pipe[0]);
         close_fd_if_open(readiness_pipe[1]);
-        close_fd_if_open(binding.fd);
+        close_fd_if_open(request_channel[0]);
+        close_fd_if_open(request_channel[1]);
         throw std::runtime_error(
             std::string("worker fork failed: ") + std::strerror(error_number));
       }
 
       if (pid == 0)
       {
+        rb_thread_atfork();
         close_fd_if_open(readiness_pipe[0]);
-        run_worker_process(binding.fd, binding.port, max_request_head_bytes, readiness_pipe[1]);
+        close_fd_if_open(request_channel[0]);
+        run_worker_process(request_channel[1], port, max_request_head_bytes, readiness_pipe[1]);
       }
 
-      set_worker_pid(pid);
+      close_fd_if_open(request_channel[1]);
+      set_worker_runtime(pid, request_channel[0]);
       replay_pending_stop_if_needed();
       close_fd_if_open(readiness_pipe[1]);
 
@@ -1147,7 +1184,6 @@ namespace VajraNative
       catch (...)
       {
         close_fd_if_open(readiness_pipe[0]);
-        close_fd_if_open(binding.fd);
         stop_worker_process();
         reap_worker_process(pid);
         clear_worker_pid();
@@ -1157,7 +1193,6 @@ namespace VajraNative
 
       if (report.status == WorkerBootstrapStatus::failed)
       {
-        close_fd_if_open(binding.fd);
         reap_worker_process(pid);
         clear_worker_pid();
         const auto &diagnostic = report.diagnostic.value();
@@ -1166,7 +1201,8 @@ namespace VajraNative
             diagnostic.message);
       }
 
-      close_fd_if_open(binding.fd);
+      run_master_runtime_server(port, max_request_head_bytes, request_channel[0]);
+      stop_worker_process();
       wait_for_worker_exit(pid);
       clear_worker_pid();
     }
@@ -1179,10 +1215,7 @@ namespace VajraNative
 
   void stop()
   {
-    if (stop_worker_process())
-    {
-      return;
-    }
+    (void)stop_worker_process();
 
     std::lock_guard<std::mutex> lock(server_mutex);
     if (server_instance)

--- a/gems/vajra/spec/cpp/CMakeLists.txt
+++ b/gems/vajra/spec/cpp/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(vajra_server_test
   ../../ext/vajra/ipc/frame_header.cpp
   ../../ext/vajra/listener/listener_socket.cpp
   ../../ext/vajra/request/request_body_reader.cpp
+  ../../ext/vajra/request/request_executor.cpp
   ../../ext/vajra/request/request_head_reader.cpp
   ../../ext/vajra/request/request_processor.cpp
   ../../ext/vajra/request/rack_env.cpp

--- a/gems/vajra/spec/e2e/vajra/configuration_spec.rb
+++ b/gems/vajra/spec/e2e/vajra/configuration_spec.rb
@@ -76,6 +76,22 @@ RSpec.describe 'Vajra configuration', :e2e, :integration do # rubocop:disable RS
     )
   end
 
+  it 'fails startup when Vajra.start is invoked from a non-main Ruby thread' do
+    failure = startup_failure_with_inline_script(<<~RUBY)
+      require "vajra"
+
+      worker = Thread.new { Vajra.start }
+      worker.join
+    RUBY
+
+    expect(failure).to match(
+      exitstatus: be_positive,
+      output: a_string_including(
+        'Unable to start Vajra: worker-only Vajra.start must be invoked from the Ruby main thread'
+      )
+    )
+  end
+
   it 'fails startup with actionable Ruby boot diagnostics' do
     failure = startup_failure_with_inline_script(<<~RUBY)
       require "vajra"

--- a/gems/vajra/spec/e2e/vajra/lifecycle_spec.rb
+++ b/gems/vajra/spec/e2e/vajra/lifecycle_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe 'Vajra lifecycle', :e2e, :integration do # rubocop:disable RSpec/
       'event=stop_completed',
       'boot_status=ready',
       'mode=master_worker',
-      'runtime_role=ruby_worker_bootstrap',
       'worker_processes=1'
     )
 

--- a/gems/vajra/spec/e2e/vajra/support/process_helpers.rb
+++ b/gems/vajra/spec/e2e/vajra/support/process_helpers.rb
@@ -112,13 +112,13 @@ module VajraE2EProcessHelpers
       require "vajra"
       Thread.report_on_exception = false
 
-      server_thread = Thread.new { Vajra.start }
-      begin
+      stopper_thread = Thread.new do
         STDIN.read
-      ensure
         Vajra.stop
-        Timeout.timeout(5) { server_thread.join }
       end
+
+      Vajra.start
+      Timeout.timeout(5) { stopper_thread.join }
     RUBY
 
     Open3.popen2e(vajra_env(port:).merge(env), *inline_ruby_command(script), chdir: VajraE2EHelpers::PACKAGE_ROOT) do |stdin, output, wait_thread|

--- a/gems/vajra/spec/e2e/vajra/support/startup_helpers.rb
+++ b/gems/vajra/spec/e2e/vajra/support/startup_helpers.rb
@@ -93,17 +93,19 @@ module VajraE2EStartupHelpers
 
       Vajra.stop if #{stop_before_start ? 'true' : 'false'}
 
-      server_thread = Thread.new { Vajra.start }
-
-      Timeout.timeout(5) do
-        loop do
-          break if server_ready?(host, port)
-          sleep 0.01
+      stopper_thread = Thread.new do
+        Timeout.timeout(5) do
+          loop do
+            break if server_ready?(host, port)
+            sleep 0.01
+          end
         end
+
+        Vajra.stop
       end
 
-      Vajra.stop
-      Timeout.timeout(5) { server_thread.join }
+      Vajra.start
+      Timeout.timeout(5) { stopper_thread.join }
 
       rebound_server = TCPServer.new(bind_host, port)
       rebound_server.close


### PR DESCRIPTION
- move listener ownership and request transport back to the native runtime
- execute Rack requests in Ruby workers over full-duplex request-channel IPC
- stream request bodies to workers and response bodies back to the runtime
- require main-thread startup for worker boot and remove supported same-process fallback
- fix worker shutdown and post-fork runtime behavior for clean stop and e2e stability
- update docs to describe the product runtime model instead of backlog/status language.

closes: #57
closes: #66
closes: #67
