### PR TITLE
feat: interrupt active client sockets on drain

### DIFF
--- a/gems/vajra/ext/vajra/request/request_head_reader.cpp
+++ b/gems/vajra/ext/vajra/request/request_head_reader.cpp
@@ -16,6 +16,11 @@ namespace
 {
   constexpr const char *kHeaderBoundary = "\r\n\r\n";
   constexpr std::size_t kHeaderBoundaryLength = 4;
+
+  bool drain_interrupted_recv_error(int error_number)
+  {
+    return error_number == ECONNRESET || error_number == ECONNABORTED || error_number == ENOTCONN;
+  }
 }
 
 Vajra::request::HeadReader::HeadReader(std::size_t max_request_head_bytes, int continuation_timeout_seconds)
@@ -72,6 +77,10 @@ Vajra::request::HeadReadResult Vajra::request::HeadReader::read(
       }
 
       if (errno == EAGAIN || errno == EWOULDBLOCK)
+      {
+        return HeadReadResult{false, request_head, ""};
+      }
+      if (drain_interrupted_recv_error(errno))
       {
         return HeadReadResult{false, request_head, ""};
       }

--- a/gems/vajra/ext/vajra/request/request_head_reader.cpp
+++ b/gems/vajra/ext/vajra/request/request_head_reader.cpp
@@ -17,7 +17,7 @@ namespace
   constexpr const char *kHeaderBoundary = "\r\n\r\n";
   constexpr std::size_t kHeaderBoundaryLength = 4;
 
-  bool drain_interrupted_recv_error(int error_number)
+  bool peer_closed_recv_error(int error_number)
   {
     return error_number == ECONNRESET || error_number == ECONNABORTED || error_number == ENOTCONN;
   }
@@ -80,7 +80,7 @@ Vajra::request::HeadReadResult Vajra::request::HeadReader::read(
       {
         return HeadReadResult{false, request_head, ""};
       }
-      if (drain_interrupted_recv_error(errno))
+      if (peer_closed_recv_error(errno))
       {
         return HeadReadResult{false, request_head, ""};
       }

--- a/gems/vajra/ext/vajra/server.cpp
+++ b/gems/vajra/ext/vajra/server.cpp
@@ -330,6 +330,11 @@ Vajra::Server::Server(
 Vajra::Server::~Server()
 {
   close_listener_fd(false);
+  const lifecycle::Snapshot snapshot = lifecycle_.snapshot();
+  if (snapshot.state == lifecycle::State::draining || snapshot.state == lifecycle::State::failed)
+  {
+    interrupt_active_client_sockets();
+  }
   join_handler_threads();
 }
 
@@ -367,6 +372,44 @@ void Vajra::Server::join_handler_threads()
     if (thread.joinable())
     {
       thread.join();
+    }
+  }
+}
+
+void Vajra::Server::register_active_client_fd(int client_fd)
+{
+  std::lock_guard<std::mutex> lock(active_client_fds_mutex_);
+  active_client_fds_.insert(client_fd);
+}
+
+void Vajra::Server::unregister_active_client_fd(int client_fd)
+{
+  std::lock_guard<std::mutex> lock(active_client_fds_mutex_);
+  active_client_fds_.erase(client_fd);
+}
+
+void Vajra::Server::interrupt_active_client_sockets()
+{
+  std::vector<int> active_client_fds;
+  {
+    std::lock_guard<std::mutex> lock(active_client_fds_mutex_);
+    active_client_fds.reserve(active_client_fds_.size());
+    for (int client_fd : active_client_fds_)
+    {
+      active_client_fds.push_back(client_fd);
+    }
+  }
+
+  for (int client_fd : active_client_fds)
+  {
+    if (shutdown(client_fd, SHUT_RDWR) == 0)
+    {
+      continue;
+    }
+
+    if (errno == ENOTCONN || errno == EINVAL || errno == EBADF)
+    {
+      continue;
     }
   }
 }
@@ -451,6 +494,7 @@ void Vajra::Server::start()
           shutdown_begin_callback_();
         }
         lifecycle_.request_stop(lifecycle::StopReason::signal_shutdown);
+        interrupt_active_client_sockets();
         break;
       }
 
@@ -513,6 +557,7 @@ void Vajra::Server::start()
               shutdown_begin_callback_();
             }
             lifecycle_.request_stop(lifecycle::StopReason::signal_shutdown);
+            interrupt_active_client_sockets();
           }
           break;
         }
@@ -532,11 +577,13 @@ void Vajra::Server::start()
       }
 
       reap_completed_handler_threads();
+      register_active_client_fd(client_fd);
 
       const std::size_t previous_active_connections = active_connection_count_.fetch_add(1, std::memory_order_acq_rel);
       if (previous_active_connections >= max_connections_)
       {
         active_connection_count_.fetch_sub(1, std::memory_order_acq_rel);
+        unregister_active_client_fd(client_fd);
         log_connection_rejected(max_connections_);
         close(client_fd);
         continue;
@@ -562,6 +609,7 @@ void Vajra::Server::start()
           {
             log_handler_thread_failure(client_addr, client_fd, "unknown exception");
           }
+          unregister_active_client_fd(client_fd);
           completed->store(true, std::memory_order_release);
         });
       }
@@ -571,9 +619,10 @@ void Vajra::Server::start()
         if (!handler_threads_.empty() && handler_threads_.back().thread.joinable() == false &&
             handler_threads_.back().completed == completed)
         {
-          handler_threads_.pop_back();
+            handler_threads_.pop_back();
         }
         active_connection_count_.fetch_sub(1, std::memory_order_acq_rel);
+        unregister_active_client_fd(client_fd);
         close(client_fd);
         throw;
       }
@@ -582,12 +631,22 @@ void Vajra::Server::start()
   catch (...)
   {
     close_listener_fd(false);
+    const lifecycle::Snapshot snapshot = lifecycle_.snapshot();
+    if (snapshot.state == lifecycle::State::draining || snapshot.state == lifecycle::State::failed)
+    {
+      interrupt_active_client_sockets();
+    }
     join_handler_threads();
     lifecycle_.finish_stop();
     throw;
   }
 
   close_listener_fd(false);
+  const lifecycle::Snapshot snapshot = lifecycle_.snapshot();
+  if (snapshot.state == lifecycle::State::draining || snapshot.state == lifecycle::State::failed)
+  {
+    interrupt_active_client_sockets();
+  }
   join_handler_threads();
   lifecycle_.finish_stop();
 }
@@ -600,6 +659,7 @@ void Vajra::Server::stop()
   }
   lifecycle_.request_stop(lifecycle::StopReason::programmatic_stop);
   close_listener_fd(true);
+  interrupt_active_client_sockets();
 }
 
 Vajra::lifecycle::Snapshot Vajra::Server::lifecycle_snapshot() const

--- a/gems/vajra/ext/vajra/server.cpp
+++ b/gems/vajra/ext/vajra/server.cpp
@@ -26,13 +26,14 @@ namespace
 {
   constexpr const char *kUnknownSocketAddress = "0.0.0.0";
   constexpr int kHandlerReapPollTimeoutMilliseconds = 1000;
+  constexpr int kDuplicateFdMinimum = STDERR_FILENO + 1;
 
   int duplicate_fd_cloexec(int fd)
   {
 #ifdef F_DUPFD_CLOEXEC
-    return fcntl(fd, F_DUPFD_CLOEXEC, 0);
+    return fcntl(fd, F_DUPFD_CLOEXEC, kDuplicateFdMinimum);
 #else
-    const int duplicated_fd = dup(fd);
+    const int duplicated_fd = fcntl(fd, F_DUPFD, kDuplicateFdMinimum);
     if (duplicated_fd < 0)
     {
       return duplicated_fd;
@@ -233,6 +234,13 @@ namespace
   {
     std::ostringstream message;
     message << "accept failed: " << error_message;
+    log_message("error", message.str(), std::cerr);
+  }
+
+  void log_active_client_tracking_failed(const char *error_message)
+  {
+    std::ostringstream message;
+    message << "active client tracking failed: " << error_message;
     log_message("error", message.str(), std::cerr);
   }
 
@@ -677,7 +685,7 @@ void Vajra::Server::start()
       }
       catch (const std::exception &error)
       {
-        log_accept_failed(error.what());
+        log_active_client_tracking_failed(error.what());
         close(client_fd);
         continue;
       }

--- a/gems/vajra/ext/vajra/server.cpp
+++ b/gems/vajra/ext/vajra/server.cpp
@@ -234,6 +234,13 @@ namespace
     log_message("error", error_message.str(), std::cerr);
   }
 
+  void log_client_socket_interrupt_failed(int client_fd, const char *error_message)
+  {
+    std::ostringstream message;
+    message << "client socket interrupt failed: client_fd=" << client_fd << " error=" << error_message;
+    log_message("error", message.str(), std::cerr);
+  }
+
   class ActiveConnectionGuard
   {
   public:
@@ -376,16 +383,24 @@ void Vajra::Server::join_handler_threads()
   }
 }
 
-void Vajra::Server::register_active_client_fd(int client_fd)
+std::uint64_t Vajra::Server::register_active_client_fd(int client_fd)
 {
+  const std::uint64_t client_token = next_active_client_token_.fetch_add(1, std::memory_order_acq_rel) + 1;
   std::lock_guard<std::mutex> lock(active_client_fds_mutex_);
-  active_client_fds_.insert(client_fd);
+  active_client_fds_[client_fd] = client_token;
+  return client_token;
 }
 
-void Vajra::Server::unregister_active_client_fd(int client_fd)
+void Vajra::Server::unregister_active_client_fd(int client_fd, std::uint64_t client_token)
 {
   std::lock_guard<std::mutex> lock(active_client_fds_mutex_);
-  active_client_fds_.erase(client_fd);
+  const auto active_client_fd = active_client_fds_.find(client_fd);
+  if (active_client_fd == active_client_fds_.end() || active_client_fd->second != client_token)
+  {
+    return;
+  }
+
+  active_client_fds_.erase(active_client_fd);
 }
 
 void Vajra::Server::interrupt_active_client_sockets()
@@ -394,22 +409,33 @@ void Vajra::Server::interrupt_active_client_sockets()
   {
     std::lock_guard<std::mutex> lock(active_client_fds_mutex_);
     active_client_fds.reserve(active_client_fds_.size());
-    for (int client_fd : active_client_fds_)
+    for (const auto &[client_fd, client_token] : active_client_fds_)
     {
+      (void)client_token;
       active_client_fds.push_back(client_fd);
     }
   }
 
   for (int client_fd : active_client_fds)
   {
-    if (shutdown(client_fd, SHUT_RDWR) == 0)
+    for (;;)
     {
-      continue;
-    }
+      if (shutdown(client_fd, SHUT_RDWR) == 0)
+      {
+        break;
+      }
 
-    if (errno == ENOTCONN || errno == EINVAL || errno == EBADF)
-    {
-      continue;
+      if (errno == EINTR)
+      {
+        continue;
+      }
+      if (errno == ENOTCONN || errno == EINVAL || errno == EBADF)
+      {
+        break;
+      }
+
+      log_client_socket_interrupt_failed(client_fd, std::strerror(errno));
+      break;
     }
   }
 }
@@ -577,13 +603,13 @@ void Vajra::Server::start()
       }
 
       reap_completed_handler_threads();
-      register_active_client_fd(client_fd);
+      const std::uint64_t client_token = register_active_client_fd(client_fd);
 
       const std::size_t previous_active_connections = active_connection_count_.fetch_add(1, std::memory_order_acq_rel);
       if (previous_active_connections >= max_connections_)
       {
         active_connection_count_.fetch_sub(1, std::memory_order_acq_rel);
-        unregister_active_client_fd(client_fd);
+        unregister_active_client_fd(client_fd, client_token);
         log_connection_rejected(max_connections_);
         close(client_fd);
         continue;
@@ -595,7 +621,7 @@ void Vajra::Server::start()
         std::lock_guard<std::mutex> lock(handler_threads_mutex_);
         handler_threads_.push_back(HandlerThread{std::thread(), completed});
         HandlerThread &handler_thread = handler_threads_.back();
-        handler_thread.thread = std::thread([this, client_fd, client_addr, completed]() {
+        handler_thread.thread = std::thread([this, client_fd, client_addr, completed, client_token]() {
           ActiveConnectionGuard active_connection_guard(active_connection_count_);
           try
           {
@@ -609,7 +635,7 @@ void Vajra::Server::start()
           {
             log_handler_thread_failure(client_addr, client_fd, "unknown exception");
           }
-          unregister_active_client_fd(client_fd);
+          unregister_active_client_fd(client_fd, client_token);
           completed->store(true, std::memory_order_release);
         });
       }
@@ -622,7 +648,7 @@ void Vajra::Server::start()
           handler_threads_.pop_back();
         }
         active_connection_count_.fetch_sub(1, std::memory_order_acq_rel);
-        unregister_active_client_fd(client_fd);
+        unregister_active_client_fd(client_fd, client_token);
         close(client_fd);
         throw;
       }

--- a/gems/vajra/ext/vajra/server.cpp
+++ b/gems/vajra/ext/vajra/server.cpp
@@ -619,7 +619,7 @@ void Vajra::Server::start()
         if (!handler_threads_.empty() && handler_threads_.back().thread.joinable() == false &&
             handler_threads_.back().completed == completed)
         {
-            handler_threads_.pop_back();
+          handler_threads_.pop_back();
         }
         active_connection_count_.fetch_sub(1, std::memory_order_acq_rel);
         unregister_active_client_fd(client_fd);

--- a/gems/vajra/ext/vajra/server.cpp
+++ b/gems/vajra/ext/vajra/server.cpp
@@ -28,6 +28,8 @@ namespace
   constexpr int kHandlerReapPollTimeoutMilliseconds = 1000;
   constexpr int kDuplicateFdMinimum = STDERR_FILENO + 1;
 
+  void log_client_socket_interrupt_failed(int client_fd, const char *error_message);
+
   int duplicate_fd_cloexec(int fd)
   {
 #ifdef F_DUPFD_CLOEXEC
@@ -58,6 +60,31 @@ namespace
 
     return duplicated_fd;
 #endif
+  }
+
+  bool shutdown_interrupt_succeeded_or_expected(int fd, int original_fd)
+  {
+    for (;;)
+    {
+      if (shutdown(fd, SHUT_RDWR) == 0)
+      {
+        return true;
+      }
+
+      if (errno == EINTR)
+      {
+        continue;
+      }
+      // Ignore shutdown-time races where a handler closes the socket or the fd
+      // is recycled before this best-effort interrupt reaches shutdown(2).
+      if (errno == ENOTCONN || errno == EINVAL || errno == EBADF || errno == ENOTSOCK)
+      {
+        return true;
+      }
+
+      log_client_socket_interrupt_failed(original_fd, std::strerror(errno));
+      return false;
+    }
   }
 
   std::string socket_address(sockaddr_in address)
@@ -488,6 +515,12 @@ void Vajra::Server::interrupt_active_client_sockets()
           continue;
         }
 
+        if (errno == EMFILE || errno == ENFILE)
+        {
+          shutdown_interrupt_succeeded_or_expected(registration.interrupt_fd, registration.original_fd);
+          continue;
+        }
+
         log_client_socket_interrupt_failed(registration.original_fd, std::strerror(errno));
         continue;
       }
@@ -498,28 +531,7 @@ void Vajra::Server::interrupt_active_client_sockets()
 
   for (const auto &[original_fd, interrupt_fd] : interrupt_fds)
   {
-    for (;;)
-    {
-      if (shutdown(interrupt_fd, SHUT_RDWR) == 0)
-      {
-        break;
-      }
-
-      if (errno == EINTR)
-      {
-        continue;
-      }
-      // Ignore shutdown-time races where a handler closes the socket or the fd
-      // is recycled before this best-effort interrupt reaches shutdown(2).
-      if (errno == ENOTCONN || errno == EINVAL || errno == EBADF || errno == ENOTSOCK)
-      {
-        break;
-      }
-
-      log_client_socket_interrupt_failed(original_fd, std::strerror(errno));
-      break;
-    }
-
+    shutdown_interrupt_succeeded_or_expected(interrupt_fd, original_fd);
     close(interrupt_fd);
   }
 }
@@ -687,6 +699,15 @@ void Vajra::Server::start()
       }
 
       reap_completed_handler_threads();
+      const std::size_t previous_active_connections = active_connection_count_.fetch_add(1, std::memory_order_acq_rel);
+      if (previous_active_connections >= max_connections_)
+      {
+        active_connection_count_.fetch_sub(1, std::memory_order_acq_rel);
+        log_connection_rejected(max_connections_);
+        close(client_fd);
+        continue;
+      }
+
       std::uint64_t client_token = 0;
       try
       {
@@ -694,17 +715,8 @@ void Vajra::Server::start()
       }
       catch (const std::exception &error)
       {
-        log_active_client_tracking_failed(error.what());
-        close(client_fd);
-        continue;
-      }
-
-      const std::size_t previous_active_connections = active_connection_count_.fetch_add(1, std::memory_order_acq_rel);
-      if (previous_active_connections >= max_connections_)
-      {
         active_connection_count_.fetch_sub(1, std::memory_order_acq_rel);
-        unregister_active_client_fd(client_fd, client_token);
-        log_connection_rejected(max_connections_);
+        log_active_client_tracking_failed(error.what());
         close(client_fd);
         continue;
       }

--- a/gems/vajra/ext/vajra/server.cpp
+++ b/gems/vajra/ext/vajra/server.cpp
@@ -388,7 +388,10 @@ std::uint64_t Vajra::Server::register_active_client_fd(int client_fd)
   const int interrupt_fd = dup(client_fd);
   if (interrupt_fd < 0)
   {
-    throw std::runtime_error("dup failed while tracking active client socket");
+    std::ostringstream error_message;
+    error_message << "dup failed while tracking active client socket fd=" << client_fd
+                  << ": " << std::strerror(errno);
+    throw std::runtime_error(error_message.str());
   }
 
   const std::uint64_t client_token = next_active_client_token_.fetch_add(1, std::memory_order_acq_rel) + 1;
@@ -417,18 +420,30 @@ void Vajra::Server::unregister_active_client_fd(int client_fd, std::uint64_t cli
 
 void Vajra::Server::interrupt_active_client_sockets()
 {
-  std::vector<int> active_client_fds;
+  std::vector<int> interrupt_fds;
   {
     std::lock_guard<std::mutex> lock(active_client_fds_mutex_);
-    active_client_fds.reserve(active_client_fds_.size());
+    interrupt_fds.reserve(active_client_fds_.size());
     for (const auto &[client_token, registration] : active_client_fds_)
     {
       (void)client_token;
-      active_client_fds.push_back(registration.interrupt_fd);
+      const int interrupt_fd = dup(registration.interrupt_fd);
+      if (interrupt_fd < 0)
+      {
+        if (errno == EBADF)
+        {
+          continue;
+        }
+
+        log_client_socket_interrupt_failed(registration.original_fd, std::strerror(errno));
+        continue;
+      }
+
+      interrupt_fds.push_back(interrupt_fd);
     }
   }
 
-  for (int client_fd : active_client_fds)
+  for (int client_fd : interrupt_fds)
   {
     for (;;)
     {
@@ -451,6 +466,8 @@ void Vajra::Server::interrupt_active_client_sockets()
       log_client_socket_interrupt_failed(client_fd, std::strerror(errno));
       break;
     }
+
+    close(client_fd);
   }
 }
 

--- a/gems/vajra/ext/vajra/server.cpp
+++ b/gems/vajra/ext/vajra/server.cpp
@@ -385,22 +385,34 @@ void Vajra::Server::join_handler_threads()
 
 std::uint64_t Vajra::Server::register_active_client_fd(int client_fd)
 {
+  const int interrupt_fd = dup(client_fd);
+  if (interrupt_fd < 0)
+  {
+    throw std::runtime_error("dup failed while tracking active client socket");
+  }
+
   const std::uint64_t client_token = next_active_client_token_.fetch_add(1, std::memory_order_acq_rel) + 1;
   std::lock_guard<std::mutex> lock(active_client_fds_mutex_);
-  active_client_fds_[client_fd] = client_token;
+  active_client_fds_[client_token] = ActiveClientRegistration{client_fd, interrupt_fd};
   return client_token;
 }
 
 void Vajra::Server::unregister_active_client_fd(int client_fd, std::uint64_t client_token)
 {
+  int interrupt_fd = -1;
   std::lock_guard<std::mutex> lock(active_client_fds_mutex_);
-  const auto active_client_fd = active_client_fds_.find(client_fd);
-  if (active_client_fd == active_client_fds_.end() || active_client_fd->second != client_token)
+  const auto active_client_fd = active_client_fds_.find(client_token);
+  if (active_client_fd == active_client_fds_.end() || active_client_fd->second.original_fd != client_fd)
   {
     return;
   }
 
+  interrupt_fd = active_client_fd->second.interrupt_fd;
   active_client_fds_.erase(active_client_fd);
+  if (interrupt_fd >= 0)
+  {
+    close(interrupt_fd);
+  }
 }
 
 void Vajra::Server::interrupt_active_client_sockets()
@@ -409,10 +421,10 @@ void Vajra::Server::interrupt_active_client_sockets()
   {
     std::lock_guard<std::mutex> lock(active_client_fds_mutex_);
     active_client_fds.reserve(active_client_fds_.size());
-    for (const auto &[client_fd, client_token] : active_client_fds_)
+    for (const auto &[client_token, registration] : active_client_fds_)
     {
       (void)client_token;
-      active_client_fds.push_back(client_fd);
+      active_client_fds.push_back(registration.interrupt_fd);
     }
   }
 
@@ -605,7 +617,17 @@ void Vajra::Server::start()
       }
 
       reap_completed_handler_threads();
-      const std::uint64_t client_token = register_active_client_fd(client_fd);
+      std::uint64_t client_token = 0;
+      try
+      {
+        client_token = register_active_client_fd(client_fd);
+      }
+      catch (const std::exception &error)
+      {
+        log_accept_failed(error.what());
+        close(client_fd);
+        continue;
+      }
 
       const std::size_t previous_active_connections = active_connection_count_.fetch_add(1, std::memory_order_acq_rel);
       if (previous_active_connections >= max_connections_)

--- a/gems/vajra/ext/vajra/server.cpp
+++ b/gems/vajra/ext/vajra/server.cpp
@@ -12,6 +12,7 @@
 #include <cstring>
 #include <cstdint>
 #include <ctime>
+#include <fcntl.h>
 #include <iomanip>
 #include <iostream>
 #include <poll.h>
@@ -25,6 +26,38 @@ namespace
 {
   constexpr const char *kUnknownSocketAddress = "0.0.0.0";
   constexpr int kHandlerReapPollTimeoutMilliseconds = 1000;
+
+  int duplicate_fd_cloexec(int fd)
+  {
+#ifdef F_DUPFD_CLOEXEC
+    return fcntl(fd, F_DUPFD_CLOEXEC, 0);
+#else
+    const int duplicated_fd = dup(fd);
+    if (duplicated_fd < 0)
+    {
+      return duplicated_fd;
+    }
+
+    const int existing_flags = fcntl(duplicated_fd, F_GETFD);
+    if (existing_flags < 0)
+    {
+      const int error_number = errno;
+      close(duplicated_fd);
+      errno = error_number;
+      return -1;
+    }
+
+    if (fcntl(duplicated_fd, F_SETFD, existing_flags | FD_CLOEXEC) < 0)
+    {
+      const int error_number = errno;
+      close(duplicated_fd);
+      errno = error_number;
+      return -1;
+    }
+
+    return duplicated_fd;
+#endif
+  }
 
   std::string socket_address(sockaddr_in address)
   {
@@ -385,7 +418,7 @@ void Vajra::Server::join_handler_threads()
 
 std::uint64_t Vajra::Server::register_active_client_fd(int client_fd)
 {
-  const int interrupt_fd = dup(client_fd);
+  const int interrupt_fd = duplicate_fd_cloexec(client_fd);
   if (interrupt_fd < 0)
   {
     std::ostringstream error_message;
@@ -403,15 +436,18 @@ std::uint64_t Vajra::Server::register_active_client_fd(int client_fd)
 void Vajra::Server::unregister_active_client_fd(int client_fd, std::uint64_t client_token)
 {
   int interrupt_fd = -1;
-  std::lock_guard<std::mutex> lock(active_client_fds_mutex_);
-  const auto active_client_fd = active_client_fds_.find(client_token);
-  if (active_client_fd == active_client_fds_.end() || active_client_fd->second.original_fd != client_fd)
   {
-    return;
+    std::lock_guard<std::mutex> lock(active_client_fds_mutex_);
+    const auto active_client_fd = active_client_fds_.find(client_token);
+    if (active_client_fd == active_client_fds_.end() || active_client_fd->second.original_fd != client_fd)
+    {
+      return;
+    }
+
+    interrupt_fd = active_client_fd->second.interrupt_fd;
+    active_client_fds_.erase(active_client_fd);
   }
 
-  interrupt_fd = active_client_fd->second.interrupt_fd;
-  active_client_fds_.erase(active_client_fd);
   if (interrupt_fd >= 0)
   {
     close(interrupt_fd);
@@ -420,14 +456,14 @@ void Vajra::Server::unregister_active_client_fd(int client_fd, std::uint64_t cli
 
 void Vajra::Server::interrupt_active_client_sockets()
 {
-  std::vector<int> interrupt_fds;
+  std::vector<std::pair<int, int>> interrupt_fds;
   {
     std::lock_guard<std::mutex> lock(active_client_fds_mutex_);
     interrupt_fds.reserve(active_client_fds_.size());
     for (const auto &[client_token, registration] : active_client_fds_)
     {
       (void)client_token;
-      const int interrupt_fd = dup(registration.interrupt_fd);
+      const int interrupt_fd = duplicate_fd_cloexec(registration.interrupt_fd);
       if (interrupt_fd < 0)
       {
         if (errno == EBADF)
@@ -439,15 +475,15 @@ void Vajra::Server::interrupt_active_client_sockets()
         continue;
       }
 
-      interrupt_fds.push_back(interrupt_fd);
+      interrupt_fds.emplace_back(registration.original_fd, interrupt_fd);
     }
   }
 
-  for (int client_fd : interrupt_fds)
+  for (const auto &[original_fd, interrupt_fd] : interrupt_fds)
   {
     for (;;)
     {
-      if (shutdown(client_fd, SHUT_RDWR) == 0)
+      if (shutdown(interrupt_fd, SHUT_RDWR) == 0)
       {
         break;
       }
@@ -463,11 +499,11 @@ void Vajra::Server::interrupt_active_client_sockets()
         break;
       }
 
-      log_client_socket_interrupt_failed(client_fd, std::strerror(errno));
+      log_client_socket_interrupt_failed(original_fd, std::strerror(errno));
       break;
     }
 
-    close(client_fd);
+    close(interrupt_fd);
   }
 }
 

--- a/gems/vajra/ext/vajra/server.cpp
+++ b/gems/vajra/ext/vajra/server.cpp
@@ -35,16 +35,6 @@ namespace
 
   void log_client_socket_interrupt_failed(int client_fd, const char *error_message);
 
-  std::size_t checked_multiply(std::size_t left, std::size_t right, const char *error_message)
-  {
-    if (left != 0 && right > (std::numeric_limits<std::size_t>::max() / left))
-    {
-      throw std::runtime_error(error_message);
-    }
-
-    return left * right;
-  }
-
   std::size_t checked_add(std::size_t left, std::size_t right, const char *error_message)
   {
     if (right > (std::numeric_limits<std::size_t>::max() - left))
@@ -55,38 +45,25 @@ namespace
     return left + right;
   }
 
-  void validate_connection_capacity(std::size_t max_connections)
+  std::size_t safe_max_connections_for_fd_limit()
   {
-    const std::size_t steady_state_connection_fds = checked_multiply(
-        max_connections,
-        kPerConnectionFdCost,
-        "invalid max_connections: required fd count is too large");
-    const std::size_t listener_and_connections_fds = checked_add(
-        kListenerFdCost,
-        steady_state_connection_fds,
-        "invalid max_connections: required fd count is too large");
-    const std::size_t required_fds = checked_add(
-        listener_and_connections_fds,
-        kRuntimeFdReserve,
-        "invalid max_connections: required fd count is too large");
-
     rlimit fd_limit{};
     if (getrlimit(RLIMIT_NOFILE, &fd_limit) != 0 || fd_limit.rlim_cur == RLIM_INFINITY)
     {
-      return;
+      return std::numeric_limits<std::size_t>::max();
     }
 
     const std::size_t available_fds = static_cast<std::size_t>(fd_limit.rlim_cur);
-    if (required_fds > available_fds)
+    const std::size_t fixed_fd_cost = checked_add(
+        kRuntimeFdReserve,
+        kListenerFdCost,
+        "invalid max_connections: fixed fd cost is too large");
+    if (available_fds <= fixed_fd_cost)
     {
-      throw std::runtime_error(
-          "invalid max_connections: " + std::to_string(max_connections) +
-          " active connections require " + std::to_string(steady_state_connection_fds) +
-          " steady-state per-connection fds (accepted socket plus drain-interrupt tracking fd), plus " +
-          std::to_string(kListenerFdCost) + " listener fd and " + std::to_string(kRuntimeFdReserve) +
-          " runtime reserve fds, which exceeds the process fd limit of " + std::to_string(available_fds) +
-          ". Lower max_connections or raise the fd limit.");
+      return 0;
     }
+
+    return (available_fds - fixed_fd_cost) / kPerConnectionFdCost;
   }
 
   int duplicate_fd_cloexec(int fd)
@@ -368,6 +345,15 @@ namespace
     log_message("error", message.str(), std::cerr);
   }
 
+  void log_max_connections_clamped(std::size_t requested, std::size_t actual, std::size_t fd_limit)
+  {
+    std::ostringstream message;
+    message << "max_connections clamped from " << requested << " to " << actual
+            << " so steady-state accepted sockets plus drain-interrupt tracking fds fit within fd limit="
+            << fd_limit;
+    log_message("warn", message.str(), std::cerr);
+  }
+
   class ActiveConnectionGuard
   {
   public:
@@ -421,7 +407,21 @@ Vajra::Server::Server(
       max_connections_(max_connections),
       shutdown_begin_callback_(std::move(shutdown_begin_callback))
 {
-  validate_connection_capacity(max_connections_);
+  const std::size_t safe_max_connections = safe_max_connections_for_fd_limit();
+  if (safe_max_connections == 0)
+  {
+    throw std::runtime_error(
+        "invalid max_connections: fd limit is too low to keep even one accepted connection and its drain-interrupt tracking fd open");
+  }
+  if (safe_max_connections != std::numeric_limits<std::size_t>::max() && max_connections_ > safe_max_connections)
+  {
+    rlimit fd_limit{};
+    if (getrlimit(RLIMIT_NOFILE, &fd_limit) == 0 && fd_limit.rlim_cur != RLIM_INFINITY)
+    {
+      log_max_connections_clamped(max_connections_, safe_max_connections, static_cast<std::size_t>(fd_limit.rlim_cur));
+    }
+    max_connections_ = safe_max_connections;
+  }
 
   set_lifecycle_observer([this](lifecycle::HookPoint hook_point, const lifecycle::Snapshot &snapshot) {
     switch (hook_point)

--- a/gems/vajra/ext/vajra/server.cpp
+++ b/gems/vajra/ext/vajra/server.cpp
@@ -345,6 +345,13 @@ namespace
     log_message("error", message.str(), std::cerr);
   }
 
+  void log_client_socket_interrupt_aborted(const char *error_message)
+  {
+    std::ostringstream message;
+    message << "client socket interrupt aborted: " << error_message;
+    log_message("error", message.str(), std::cerr);
+  }
+
   void log_max_connections_clamped(std::size_t requested, std::size_t actual, std::size_t fd_limit)
   {
     std::ostringstream message;
@@ -559,41 +566,52 @@ void Vajra::Server::unregister_active_client_fd(int client_fd, std::uint64_t cli
   }
 }
 
-void Vajra::Server::interrupt_active_client_sockets()
+void Vajra::Server::interrupt_active_client_sockets() noexcept
 {
-  std::vector<std::pair<int, int>> interrupt_fds;
+  try
   {
-    std::lock_guard<std::mutex> lock(active_client_fds_mutex_);
-    interrupt_fds.reserve(active_client_fds_.size());
-    for (const auto &[client_token, registration] : active_client_fds_)
+    std::vector<std::pair<int, int>> interrupt_fds;
     {
-      (void)client_token;
-      const int interrupt_fd = duplicate_fd_cloexec(registration.interrupt_fd);
-      if (interrupt_fd < 0)
+      std::lock_guard<std::mutex> lock(active_client_fds_mutex_);
+      interrupt_fds.reserve(active_client_fds_.size());
+      for (const auto &[client_token, registration] : active_client_fds_)
       {
-        if (errno == EBADF)
+        (void)client_token;
+        const int interrupt_fd = duplicate_fd_cloexec(registration.interrupt_fd);
+        if (interrupt_fd < 0)
         {
+          if (errno == EBADF)
+          {
+            continue;
+          }
+
+          if (errno == EMFILE || errno == ENFILE)
+          {
+            shutdown_interrupt_succeeded_or_expected(registration.interrupt_fd, registration.original_fd);
+            continue;
+          }
+
+          log_client_socket_interrupt_failed(registration.original_fd, std::strerror(errno));
           continue;
         }
 
-        if (errno == EMFILE || errno == ENFILE)
-        {
-          shutdown_interrupt_succeeded_or_expected(registration.interrupt_fd, registration.original_fd);
-          continue;
-        }
-
-        log_client_socket_interrupt_failed(registration.original_fd, std::strerror(errno));
-        continue;
+        interrupt_fds.emplace_back(registration.original_fd, interrupt_fd);
       }
+    }
 
-      interrupt_fds.emplace_back(registration.original_fd, interrupt_fd);
+    for (const auto &[original_fd, interrupt_fd] : interrupt_fds)
+    {
+      shutdown_interrupt_succeeded_or_expected(interrupt_fd, original_fd);
+      close(interrupt_fd);
     }
   }
-
-  for (const auto &[original_fd, interrupt_fd] : interrupt_fds)
+  catch (const std::exception &error)
   {
-    shutdown_interrupt_succeeded_or_expected(interrupt_fd, original_fd);
-    close(interrupt_fd);
+    log_client_socket_interrupt_aborted(error.what());
+  }
+  catch (...)
+  {
+    log_client_socket_interrupt_aborted("unknown native error");
   }
 }
 

--- a/gems/vajra/ext/vajra/server.cpp
+++ b/gems/vajra/ext/vajra/server.cpp
@@ -436,8 +436,17 @@ std::uint64_t Vajra::Server::register_active_client_fd(int client_fd)
   }
 
   const std::uint64_t client_token = next_active_client_token_.fetch_add(1, std::memory_order_acq_rel) + 1;
-  std::lock_guard<std::mutex> lock(active_client_fds_mutex_);
-  active_client_fds_[client_token] = ActiveClientRegistration{client_fd, interrupt_fd};
+  try
+  {
+    std::lock_guard<std::mutex> lock(active_client_fds_mutex_);
+    active_client_fds_.emplace(client_token, ActiveClientRegistration{client_fd, interrupt_fd});
+  }
+  catch (...)
+  {
+    close(interrupt_fd);
+    throw;
+  }
+
   return client_token;
 }
 

--- a/gems/vajra/ext/vajra/server.cpp
+++ b/gems/vajra/ext/vajra/server.cpp
@@ -429,7 +429,9 @@ void Vajra::Server::interrupt_active_client_sockets()
       {
         continue;
       }
-      if (errno == ENOTCONN || errno == EINVAL || errno == EBADF)
+      // Ignore shutdown-time races where a handler closes the socket or the fd
+      // is recycled before this best-effort interrupt reaches shutdown(2).
+      if (errno == ENOTCONN || errno == EINVAL || errno == EBADF || errno == ENOTSOCK)
       {
         break;
       }

--- a/gems/vajra/ext/vajra/server.cpp
+++ b/gems/vajra/ext/vajra/server.cpp
@@ -15,9 +15,11 @@
 #include <fcntl.h>
 #include <iomanip>
 #include <iostream>
+#include <limits>
 #include <poll.h>
 #include <sstream>
 #include <stdexcept>
+#include <sys/resource.h>
 #include <sys/socket.h>
 #include <unistd.h>
 #include <utility>
@@ -27,8 +29,65 @@ namespace
   constexpr const char *kUnknownSocketAddress = "0.0.0.0";
   constexpr int kHandlerReapPollTimeoutMilliseconds = 1000;
   constexpr int kDuplicateFdMinimum = STDERR_FILENO + 1;
+  constexpr std::size_t kRuntimeFdReserve = 32;
+  constexpr std::size_t kPerConnectionFdCost = 2;
+  constexpr std::size_t kListenerFdCost = 1;
 
   void log_client_socket_interrupt_failed(int client_fd, const char *error_message);
+
+  std::size_t checked_multiply(std::size_t left, std::size_t right, const char *error_message)
+  {
+    if (left != 0 && right > (std::numeric_limits<std::size_t>::max() / left))
+    {
+      throw std::runtime_error(error_message);
+    }
+
+    return left * right;
+  }
+
+  std::size_t checked_add(std::size_t left, std::size_t right, const char *error_message)
+  {
+    if (right > (std::numeric_limits<std::size_t>::max() - left))
+    {
+      throw std::runtime_error(error_message);
+    }
+
+    return left + right;
+  }
+
+  void validate_connection_capacity(std::size_t max_connections)
+  {
+    const std::size_t steady_state_connection_fds = checked_multiply(
+        max_connections,
+        kPerConnectionFdCost,
+        "invalid max_connections: required fd count is too large");
+    const std::size_t listener_and_connections_fds = checked_add(
+        kListenerFdCost,
+        steady_state_connection_fds,
+        "invalid max_connections: required fd count is too large");
+    const std::size_t required_fds = checked_add(
+        listener_and_connections_fds,
+        kRuntimeFdReserve,
+        "invalid max_connections: required fd count is too large");
+
+    rlimit fd_limit{};
+    if (getrlimit(RLIMIT_NOFILE, &fd_limit) != 0 || fd_limit.rlim_cur == RLIM_INFINITY)
+    {
+      return;
+    }
+
+    const std::size_t available_fds = static_cast<std::size_t>(fd_limit.rlim_cur);
+    if (required_fds > available_fds)
+    {
+      throw std::runtime_error(
+          "invalid max_connections: " + std::to_string(max_connections) +
+          " active connections require " + std::to_string(steady_state_connection_fds) +
+          " steady-state per-connection fds (accepted socket plus drain-interrupt tracking fd), plus " +
+          std::to_string(kListenerFdCost) + " listener fd and " + std::to_string(kRuntimeFdReserve) +
+          " runtime reserve fds, which exceeds the process fd limit of " + std::to_string(available_fds) +
+          ". Lower max_connections or raise the fd limit.");
+    }
+  }
 
   int duplicate_fd_cloexec(int fd)
   {
@@ -362,6 +421,8 @@ Vajra::Server::Server(
       max_connections_(max_connections),
       shutdown_begin_callback_(std::move(shutdown_begin_callback))
 {
+  validate_connection_capacity(max_connections_);
+
   set_lifecycle_observer([this](lifecycle::HookPoint hook_point, const lifecycle::Snapshot &snapshot) {
     switch (hook_point)
     {

--- a/gems/vajra/ext/vajra/server.hpp
+++ b/gems/vajra/ext/vajra/server.hpp
@@ -9,6 +9,7 @@
 #include <cstddef>
 #include <functional>
 #include <atomic>
+#include <unordered_set>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -71,10 +72,15 @@ namespace Vajra
     std::function<void()> shutdown_begin_callback_;
     std::mutex handler_threads_mutex_;
     std::vector<HandlerThread> handler_threads_;
+    std::mutex active_client_fds_mutex_;
+    std::unordered_set<int> active_client_fds_;
 
     void close_listener_fd(bool interrupt_accept);
     void join_handler_threads();
     void reap_completed_handler_threads();
+    void register_active_client_fd(int client_fd);
+    void unregister_active_client_fd(int client_fd);
+    void interrupt_active_client_sockets();
   };
 }
 

--- a/gems/vajra/ext/vajra/server.hpp
+++ b/gems/vajra/ext/vajra/server.hpp
@@ -88,7 +88,7 @@ namespace Vajra
     void reap_completed_handler_threads();
     std::uint64_t register_active_client_fd(int client_fd);
     void unregister_active_client_fd(int client_fd, std::uint64_t client_token);
-    void interrupt_active_client_sockets();
+    void interrupt_active_client_sockets() noexcept;
   };
 }
 

--- a/gems/vajra/ext/vajra/server.hpp
+++ b/gems/vajra/ext/vajra/server.hpp
@@ -7,13 +7,14 @@
 #define VAJRA_SERVER_HPP
 
 #include <cstddef>
-#include <functional>
 #include <atomic>
-#include <unordered_set>
+#include <cstdint>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
+#include <unordered_map>
 #include <vector>
 
 #include "lifecycle/lifecycle_controller.hpp"
@@ -73,13 +74,14 @@ namespace Vajra
     std::mutex handler_threads_mutex_;
     std::vector<HandlerThread> handler_threads_;
     std::mutex active_client_fds_mutex_;
-    std::unordered_set<int> active_client_fds_;
+    std::unordered_map<int, std::uint64_t> active_client_fds_;
+    std::atomic<std::uint64_t> next_active_client_token_{0};
 
     void close_listener_fd(bool interrupt_accept);
     void join_handler_threads();
     void reap_completed_handler_threads();
-    void register_active_client_fd(int client_fd);
-    void unregister_active_client_fd(int client_fd);
+    std::uint64_t register_active_client_fd(int client_fd);
+    void unregister_active_client_fd(int client_fd, std::uint64_t client_token);
     void interrupt_active_client_sockets();
   };
 }

--- a/gems/vajra/ext/vajra/server.hpp
+++ b/gems/vajra/ext/vajra/server.hpp
@@ -51,6 +51,12 @@ namespace Vajra
     void set_lifecycle_observer(lifecycle::Controller::Observer observer);
 
   private:
+    struct ActiveClientRegistration
+    {
+      int original_fd;
+      int interrupt_fd;
+    };
+
     struct HandlerThread
     {
       std::thread thread;
@@ -74,7 +80,7 @@ namespace Vajra
     std::mutex handler_threads_mutex_;
     std::vector<HandlerThread> handler_threads_;
     std::mutex active_client_fds_mutex_;
-    std::unordered_map<int, std::uint64_t> active_client_fds_;
+    std::unordered_map<std::uint64_t, ActiveClientRegistration> active_client_fds_;
     std::atomic<std::uint64_t> next_active_client_token_{0};
 
     void close_listener_fd(bool interrupt_accept);

--- a/gems/vajra/spec/cpp/server_lifecycle_test.cpp
+++ b/gems/vajra/spec/cpp/server_lifecycle_test.cpp
@@ -16,6 +16,52 @@ namespace VajraSpecCpp
 {
   namespace
   {
+    template <typename Scenario>
+    void run_stop_interrupt_test(const Scenario &scenario, const std::string &retry_failure_message)
+    {
+      for (int attempt = 0; attempt < 10; ++attempt)
+      {
+        const int port = available_port();
+        Vajra::Server server(port, "0.0.0.0", Vajra::request::kDefaultMaxRequestHeadBytes);
+        std::exception_ptr server_error;
+
+        std::thread server_thread([&]() {
+          try
+          {
+            server.start();
+          }
+          catch (...)
+          {
+            server_error = std::current_exception();
+          }
+        });
+
+        try
+        {
+          wait_until_listening(port);
+          scenario(port, server, server_thread, server_error);
+          return;
+        }
+        catch (...)
+        {
+          if (server_thread.joinable())
+          {
+            server.stop();
+            server_thread.join();
+          }
+
+          if (bind_conflict(server_error) && attempt < 9)
+          {
+            continue;
+          }
+
+          throw;
+        }
+      }
+
+      fail(retry_failure_message);
+    }
+
     void expect_stopped_snapshot(
         const Vajra::Server &server,
         Vajra::lifecycle::StopReason expected_reason)
@@ -207,127 +253,90 @@ namespace VajraSpecCpp
 
     void test_stop_interrupts_keep_alive_connection()
     {
-      const int port = available_port();
-      Vajra::Server server(port, "0.0.0.0", Vajra::request::kDefaultMaxRequestHeadBytes);
-      std::exception_ptr server_error;
+      run_stop_interrupt_test(
+          [&](int port, Vajra::Server &server, std::thread &server_thread, const std::exception_ptr &server_error) {
+            FileDescriptorGuard client_socket(connect_to_listener(port));
+            if (client_socket.get() < 0)
+            {
+              fail("failed to connect keep-alive test client");
+            }
 
-      std::thread server_thread([&]() {
-        try
-        {
-          server.start();
-        }
-        catch (...)
-        {
-          server_error = std::current_exception();
-        }
-      });
+            suppress_sigpipe(client_socket.get());
+            if (!send_all(
+                    client_socket.get(),
+                    "GET / HTTP/1.1\r\n"
+                    "Host: localhost\r\n"
+                    "\r\n"))
+            {
+              fail("failed to send keep-alive request");
+            }
+            read_http_response(client_socket.get());
 
-      wait_until_listening(port);
-      FileDescriptorGuard client_socket(connect_to_listener(port));
-      if (client_socket.get() < 0)
-      {
-        server.stop();
-        server_thread.join();
-        fail("failed to connect keep-alive test client");
-      }
+            server.stop();
+            const bool peer_closed = peer_closed_within(client_socket.get(), 1000);
+            client_socket.close_if_open();
+            server_thread.join();
 
-      suppress_sigpipe(client_socket.get());
-      if (!send_all(
-              client_socket.get(),
-              "GET / HTTP/1.1\r\n"
-              "Host: localhost\r\n"
-              "\r\n"))
-      {
-        server.stop();
-        client_socket.close_if_open();
-        server_thread.join();
-        fail("failed to send keep-alive request");
-      }
-      read_http_response(client_socket.get());
+            if (server_error)
+            {
+              std::rethrow_exception(server_error);
+            }
+            if (!peer_closed)
+            {
+              fail("server did not interrupt keep-alive client socket during drain");
+            }
 
-      server.stop();
-      const bool peer_closed = peer_closed_within(client_socket.get(), 1000);
-      client_socket.close_if_open();
-      server_thread.join();
-
-      if (server_error)
-      {
-        std::rethrow_exception(server_error);
-      }
-      if (!peer_closed)
-      {
-        fail("server did not interrupt keep-alive client socket during drain");
-      }
-
-      expect_stopped_snapshot(server, Vajra::lifecycle::StopReason::programmatic_stop);
+            expect_stopped_snapshot(server, Vajra::lifecycle::StopReason::programmatic_stop);
+          },
+          "keep-alive interrupt test could not obtain a reusable listener port after retries");
     }
 
     void test_stop_interrupts_partial_next_request()
     {
-      const int port = available_port();
-      Vajra::Server server(port, "0.0.0.0", Vajra::request::kDefaultMaxRequestHeadBytes);
-      std::exception_ptr server_error;
+      run_stop_interrupt_test(
+          [&](int port, Vajra::Server &server, std::thread &server_thread, const std::exception_ptr &server_error) {
+            FileDescriptorGuard client_socket(connect_to_listener(port));
+            if (client_socket.get() < 0)
+            {
+              fail("failed to connect partial-next-request test client");
+            }
 
-      std::thread server_thread([&]() {
-        try
-        {
-          server.start();
-        }
-        catch (...)
-        {
-          server_error = std::current_exception();
-        }
-      });
+            suppress_sigpipe(client_socket.get());
+            if (!send_all(
+                    client_socket.get(),
+                    "GET / HTTP/1.1\r\n"
+                    "Host: localhost\r\n"
+                    "\r\n"))
+            {
+              fail("failed to send initial keep-alive request");
+            }
+            read_http_response(client_socket.get());
 
-      wait_until_listening(port);
-      FileDescriptorGuard client_socket(connect_to_listener(port));
-      if (client_socket.get() < 0)
-      {
-        server.stop();
-        server_thread.join();
-        fail("failed to connect partial-next-request test client");
-      }
+            if (!send_all(
+                    client_socket.get(),
+                    "GET /next HTTP/1.1\r\n"
+                    "Host: localhost\r\n"))
+            {
+              fail("failed to send partial next request");
+            }
 
-      suppress_sigpipe(client_socket.get());
-      if (!send_all(
-              client_socket.get(),
-              "GET / HTTP/1.1\r\n"
-              "Host: localhost\r\n"
-              "\r\n"))
-      {
-        server.stop();
-        client_socket.close_if_open();
-        server_thread.join();
-        fail("failed to send initial keep-alive request");
-      }
-      read_http_response(client_socket.get());
+            server.stop();
+            const bool peer_closed = peer_closed_within(client_socket.get(), 1000);
+            client_socket.close_if_open();
+            server_thread.join();
 
-      if (!send_all(
-              client_socket.get(),
-              "GET /next HTTP/1.1\r\n"
-              "Host: localhost\r\n"))
-      {
-        server.stop();
-        client_socket.close_if_open();
-        server_thread.join();
-        fail("failed to send partial next request");
-      }
+            if (server_error)
+            {
+              std::rethrow_exception(server_error);
+            }
+            if (!peer_closed)
+            {
+              fail("server did not interrupt partial next request during drain");
+            }
 
-      server.stop();
-      const bool peer_closed = peer_closed_within(client_socket.get(), 1000);
-      client_socket.close_if_open();
-      server_thread.join();
-
-      if (server_error)
-      {
-        std::rethrow_exception(server_error);
-      }
-      if (!peer_closed)
-      {
-        fail("server did not interrupt partial next request during drain");
-      }
-
-      expect_stopped_snapshot(server, Vajra::lifecycle::StopReason::programmatic_stop);
+            expect_stopped_snapshot(server, Vajra::lifecycle::StopReason::programmatic_stop);
+          },
+          "partial-next-request interrupt test could not obtain a reusable listener port after retries");
     }
   }
 

--- a/gems/vajra/spec/cpp/server_lifecycle_test.cpp
+++ b/gems/vajra/spec/cpp/server_lifecycle_test.cpp
@@ -44,6 +44,7 @@ namespace VajraSpecCpp
         {
           wait_until_listening(port);
           scenario(port, server);
+          server.stop();
           if (server_thread.joinable())
           {
             server_thread.join();

--- a/gems/vajra/spec/cpp/server_lifecycle_test.cpp
+++ b/gems/vajra/spec/cpp/server_lifecycle_test.cpp
@@ -16,6 +16,10 @@ namespace VajraSpecCpp
 {
   namespace
   {
+    void expect_stopped_snapshot(
+        const Vajra::Server &server,
+        Vajra::lifecycle::StopReason expected_reason);
+
     template <typename Scenario>
     void run_stop_interrupt_test(const Scenario &scenario, const std::string &retry_failure_message)
     {
@@ -39,7 +43,16 @@ namespace VajraSpecCpp
         try
         {
           wait_until_listening(port);
-          scenario(port, server, server_thread, server_error);
+          scenario(port, server);
+          if (server_thread.joinable())
+          {
+            server_thread.join();
+          }
+          if (server_error)
+          {
+            std::rethrow_exception(server_error);
+          }
+          expect_stopped_snapshot(server, Vajra::lifecycle::StopReason::programmatic_stop);
           return;
         }
         catch (...)
@@ -254,7 +267,7 @@ namespace VajraSpecCpp
     void test_stop_interrupts_keep_alive_connection()
     {
       run_stop_interrupt_test(
-          [&](int port, Vajra::Server &server, std::thread &server_thread, const std::exception_ptr &server_error) {
+          [&](int port, Vajra::Server &server) {
             FileDescriptorGuard client_socket(connect_to_listener(port));
             if (client_socket.get() < 0)
             {
@@ -275,18 +288,10 @@ namespace VajraSpecCpp
             server.stop();
             const bool peer_closed = peer_closed_within(client_socket.get(), 1000);
             client_socket.close_if_open();
-            server_thread.join();
-
-            if (server_error)
-            {
-              std::rethrow_exception(server_error);
-            }
             if (!peer_closed)
             {
               fail("server did not interrupt keep-alive client socket during drain");
             }
-
-            expect_stopped_snapshot(server, Vajra::lifecycle::StopReason::programmatic_stop);
           },
           "keep-alive interrupt test could not obtain a reusable listener port after retries");
     }
@@ -294,7 +299,7 @@ namespace VajraSpecCpp
     void test_stop_interrupts_partial_next_request()
     {
       run_stop_interrupt_test(
-          [&](int port, Vajra::Server &server, std::thread &server_thread, const std::exception_ptr &server_error) {
+          [&](int port, Vajra::Server &server) {
             FileDescriptorGuard client_socket(connect_to_listener(port));
             if (client_socket.get() < 0)
             {
@@ -323,18 +328,10 @@ namespace VajraSpecCpp
             server.stop();
             const bool peer_closed = peer_closed_within(client_socket.get(), 1000);
             client_socket.close_if_open();
-            server_thread.join();
-
-            if (server_error)
-            {
-              std::rethrow_exception(server_error);
-            }
             if (!peer_closed)
             {
               fail("server did not interrupt partial next request during drain");
             }
-
-            expect_stopped_snapshot(server, Vajra::lifecycle::StopReason::programmatic_stop);
           },
           "partial-next-request interrupt test could not obtain a reusable listener port after retries");
     }

--- a/gems/vajra/spec/cpp/server_lifecycle_test.cpp
+++ b/gems/vajra/spec/cpp/server_lifecycle_test.cpp
@@ -204,6 +204,131 @@ namespace VajraSpecCpp
       assert_can_rebind(binding.port);
       expect_stopped_snapshot(server, Vajra::lifecycle::StopReason::programmatic_stop);
     }
+
+    void test_stop_interrupts_keep_alive_connection()
+    {
+      const int port = available_port();
+      Vajra::Server server(port, "0.0.0.0", Vajra::request::kDefaultMaxRequestHeadBytes);
+      std::exception_ptr server_error;
+
+      std::thread server_thread([&]() {
+        try
+        {
+          server.start();
+        }
+        catch (...)
+        {
+          server_error = std::current_exception();
+        }
+      });
+
+      wait_until_listening(port);
+      FileDescriptorGuard client_socket(connect_to_listener(port));
+      if (client_socket.get() < 0)
+      {
+        server.stop();
+        server_thread.join();
+        fail("failed to connect keep-alive test client");
+      }
+
+      suppress_sigpipe(client_socket.get());
+      if (!send_all(
+              client_socket.get(),
+              "GET / HTTP/1.1\r\n"
+              "Host: localhost\r\n"
+              "\r\n"))
+      {
+        server.stop();
+        client_socket.close_if_open();
+        server_thread.join();
+        fail("failed to send keep-alive request");
+      }
+      read_http_response(client_socket.get());
+
+      server.stop();
+      const bool peer_closed = peer_closed_within(client_socket.get(), 1000);
+      client_socket.close_if_open();
+      server_thread.join();
+
+      if (server_error)
+      {
+        std::rethrow_exception(server_error);
+      }
+      if (!peer_closed)
+      {
+        fail("server did not interrupt keep-alive client socket during drain");
+      }
+
+      expect_stopped_snapshot(server, Vajra::lifecycle::StopReason::programmatic_stop);
+    }
+
+    void test_stop_interrupts_partial_next_request()
+    {
+      const int port = available_port();
+      Vajra::Server server(port, "0.0.0.0", Vajra::request::kDefaultMaxRequestHeadBytes);
+      std::exception_ptr server_error;
+
+      std::thread server_thread([&]() {
+        try
+        {
+          server.start();
+        }
+        catch (...)
+        {
+          server_error = std::current_exception();
+        }
+      });
+
+      wait_until_listening(port);
+      FileDescriptorGuard client_socket(connect_to_listener(port));
+      if (client_socket.get() < 0)
+      {
+        server.stop();
+        server_thread.join();
+        fail("failed to connect partial-next-request test client");
+      }
+
+      suppress_sigpipe(client_socket.get());
+      if (!send_all(
+              client_socket.get(),
+              "GET / HTTP/1.1\r\n"
+              "Host: localhost\r\n"
+              "\r\n"))
+      {
+        server.stop();
+        client_socket.close_if_open();
+        server_thread.join();
+        fail("failed to send initial keep-alive request");
+      }
+      read_http_response(client_socket.get());
+
+      if (!send_all(
+              client_socket.get(),
+              "GET /next HTTP/1.1\r\n"
+              "Host: localhost\r\n"))
+      {
+        server.stop();
+        client_socket.close_if_open();
+        server_thread.join();
+        fail("failed to send partial next request");
+      }
+
+      server.stop();
+      const bool peer_closed = peer_closed_within(client_socket.get(), 1000);
+      client_socket.close_if_open();
+      server_thread.join();
+
+      if (server_error)
+      {
+        std::rethrow_exception(server_error);
+      }
+      if (!peer_closed)
+      {
+        fail("server did not interrupt partial next request during drain");
+      }
+
+      expect_stopped_snapshot(server, Vajra::lifecycle::StopReason::programmatic_stop);
+    }
   }
 
   void run_server_lifecycle_tests()
@@ -213,5 +338,7 @@ namespace VajraSpecCpp
     test_repeated_start_stop_cycles_remain_reusable();
     test_repeated_stop_requests_are_idempotent();
     test_inherited_listener_start_and_stop_release_listener();
+    test_stop_interrupts_keep_alive_connection();
+    test_stop_interrupts_partial_next_request();
   }
 }

--- a/gems/vajra/spec/cpp/server_lifecycle_test.cpp
+++ b/gems/vajra/spec/cpp/server_lifecycle_test.cpp
@@ -10,6 +10,7 @@
 
 #include <exception>
 #include <sstream>
+#include <string>
 #include <thread>
 
 namespace VajraSpecCpp

--- a/gems/vajra/spec/cpp/server_lifecycle_test.cpp
+++ b/gems/vajra/spec/cpp/server_lifecycle_test.cpp
@@ -44,7 +44,6 @@ namespace VajraSpecCpp
         {
           wait_until_listening(port);
           scenario(port, server);
-          server.stop();
           if (server_thread.joinable())
           {
             server_thread.join();

--- a/gems/vajra/spec/e2e/vajra/lifecycle_spec.rb
+++ b/gems/vajra/spec/e2e/vajra/lifecycle_spec.rb
@@ -67,6 +67,39 @@ RSpec.describe 'Vajra lifecycle', :e2e, :integration do # rubocop:disable RSpec/
     )
   end
 
+  it 'interrupts an idle keep-alive socket during Ctrl-C drain' do
+    shutdown = keep_alive_shutdown_with_open_socket
+
+    expect(shutdown[:exitstatus]).to eq(0)
+    expect(shutdown[:response]).to include('HTTP/1.1 200 OK')
+    expect(shutdown[:socket_closed]).to be(true)
+    expect(shutdown[:immediate_output]).to include('- Gracefully shutting down workers...')
+    expect(shutdown[:output]).to include(
+      '- Gracefully shutting down workers...',
+      '=== vajra shutdown:',
+      '- Goodbye!'
+    )
+  end
+
+  it 'interrupts a partial next request instead of waiting for request head timeout during Ctrl-C drain' do
+    shutdown = keep_alive_shutdown_with_open_socket(
+      followup_chunks: [
+        "GET /next HTTP/1.1\r\n",
+        "Host: localhost\r\n"
+      ]
+    )
+
+    expect(shutdown[:exitstatus]).to eq(0)
+    expect(shutdown[:response]).to include('HTTP/1.1 200 OK')
+    expect(shutdown[:socket_closed]).to be(true)
+    expect(shutdown[:immediate_output]).to include('- Gracefully shutting down workers...')
+    expect(shutdown[:output]).to include(
+      '- Gracefully shutting down workers...',
+      '=== vajra shutdown:',
+      '- Goodbye!'
+    )
+  end
+
   it 'supports programmatic Vajra.stop and releases the listener' do
     shutdown = programmatic_shutdown
 

--- a/gems/vajra/spec/e2e/vajra/support/process_helpers.rb
+++ b/gems/vajra/spec/e2e/vajra/support/process_helpers.rb
@@ -177,7 +177,10 @@ module VajraE2EProcessHelpers
   end
 
   def wait_for_socket_close(socket)
-    Timeout.timeout(1) { socket.read == '' }
+    Timeout.timeout(1) do
+      socket.read
+      true
+    end
   rescue EOFError, Errno::ECONNRESET
     true
   end

--- a/gems/vajra/spec/e2e/vajra/support/process_helpers.rb
+++ b/gems/vajra/spec/e2e/vajra/support/process_helpers.rb
@@ -170,6 +170,58 @@ module VajraE2EProcessHelpers
     end
   end
 
+  def wait_for_graceful_shutdown_banner(output, wait_thread)
+    Timeout.timeout(1) do
+      loop do
+        captured_output = read_available_output(output)
+        break captured_output if captured_output.include?('- Gracefully shutting down workers...')
+        raise Timeout::Error if !wait_thread.alive? && captured_output.empty?
+
+        sleep 0.01
+      end
+    end
+  end
+
+  def wait_for_socket_close(socket)
+    Timeout.timeout(1) { socket.read == '' }
+  rescue EOFError, Errno::ECONNRESET
+    true
+  end
+
+  def keep_alive_shutdown_with_open_socket(
+    followup_chunks: [],
+    port: disposable_listener_port,
+    signal: 'INT',
+    exit_timeout: 2
+  )
+    Open3.popen2e(vajra_env(port:), *vajra_command, chdir: VajraE2EHelpers::PACKAGE_ROOT) do |_stdin, output, wait_thread|
+      startup_output = []
+      selected_port = wait_for_banner(output, captured_lines: startup_output)
+
+      socket = TCPSocket.new(VajraE2EHelpers::LISTENER_HOST, selected_port)
+      socket.write("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
+      response = read_raw_http_response(socket, wait_thread:, output:, request_label: 'keep_alive_shutdown_with_open_socket')
+      followup_chunks.each { |chunk| socket.write(chunk) }
+
+      Process.kill(signal, wait_thread.pid)
+      immediate_output = wait_for_graceful_shutdown_banner(output, wait_thread)
+      socket_closed = wait_for_socket_close(socket)
+      status = wait_for_exit(wait_thread, timeout: exit_timeout)
+
+      {
+        exitstatus: status.exitstatus,
+        response:,
+        socket_closed:,
+        immediate_output:,
+        output: "#{startup_output.join}#{immediate_output}#{output.read}",
+        port: selected_port
+      }
+    ensure
+      socket.close unless socket.nil? || socket.closed?
+      cleanup_process(wait_thread, output)
+    end
+  end
+
   def request_chunks_result(chunks:, port: disposable_listener_port, env: {}, timeout: 15, pause: nil)
     script = <<~RUBY
       require "timeout"

--- a/gems/vajra/spec/e2e/vajra/support/process_helpers.rb
+++ b/gems/vajra/spec/e2e/vajra/support/process_helpers.rb
@@ -147,15 +147,7 @@ module VajraE2EProcessHelpers
       socket.close
 
       Process.kill(signal, wait_thread.pid)
-      immediate_output = Timeout.timeout(1) do
-        loop do
-          captured_output = read_available_output(output)
-          break captured_output if captured_output.include?('- Gracefully shutting down workers...')
-          raise Timeout::Error if !wait_thread.alive? && captured_output.empty?
-
-          sleep 0.01
-        end
-      end
+      immediate_output = wait_for_graceful_shutdown_banner(output, wait_thread)
       status = wait_for_exit(wait_thread)
 
       {
@@ -171,9 +163,11 @@ module VajraE2EProcessHelpers
   end
 
   def wait_for_graceful_shutdown_banner(output, wait_thread)
+    captured_output = +''
+
     Timeout.timeout(1) do
       loop do
-        captured_output = read_available_output(output)
+        captured_output << read_available_output(output)
         break captured_output if captured_output.include?('- Gracefully shutting down workers...')
         raise Timeout::Error if !wait_thread.alive? && captured_output.empty?
 

--- a/gems/vajra/spec/e2e/vajra/support/process_helpers.rb
+++ b/gems/vajra/spec/e2e/vajra/support/process_helpers.rb
@@ -181,6 +181,8 @@ module VajraE2EProcessHelpers
       socket.read
       true
     end
+  rescue Timeout::Error
+    false
   rescue EOFError, Errno::ECONNRESET
     true
   end

--- a/gems/vajra/spec/e2e/vajra/support/process_helpers.rb
+++ b/gems/vajra/spec/e2e/vajra/support/process_helpers.rb
@@ -178,12 +178,11 @@ module VajraE2EProcessHelpers
 
   def wait_for_socket_close(socket)
     Timeout.timeout(1) do
-      socket.read
-      true
+      socket.read == ''
     end
   rescue Timeout::Error
     false
-  rescue EOFError, Errno::ECONNRESET
+  rescue Errno::ECONNRESET
     true
   end
 


### PR DESCRIPTION
- Added functionality to interrupt active client sockets during server shutdown.
- Implemented methods to register and unregister active client file descriptors.
- Enhanced lifecycle management by ensuring active connections are properly handled during drain states.
- Added tests to verify that keep-alive connections and partial requests are interrupted as expected during shutdown.

closes: #386
